### PR TITLE
Preserve XML tags while removing HTML tags

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,8 +120,10 @@ export function cleanMarkdownContent(content: string, excludeImports: boolean = 
     cleaned = cleaned.replace(/^\s*import\s+.*?;?\s*$/gm, '');
   }
   
-  // Remove HTML tags
-  cleaned = cleaned.replace(/<[^>]*>/g, '');
+  // Remove HTML tags, but preserve XML content in code blocks
+  // We need to be selective to avoid removing XML content from code blocks
+  // This regex targets common HTML tags while being more conservative about XML
+  cleaned = cleaned.replace(/<\/?(?:div|span|p|br|hr|img|a|strong|em|b|i|u|h[1-6]|ul|ol|li|table|tr|td|th|thead|tbody)\b[^>]*>/gi, '');
   
   // Remove redundant content that just repeats the heading (if requested)
   if (removeDuplicateHeadings) {

--- a/tests/test-description-extraction.js
+++ b/tests/test-description-extraction.js
@@ -7,6 +7,7 @@
 const fs = require('fs').promises;
 const path = require('path');
 const matter = require('gray-matter');
+const { cleanMarkdownContent } = require('../lib/utils');
 
 // Simplified version of the processor's description extraction logic for testing
 function extractAndCleanDescription(content) {
@@ -335,4 +336,41 @@ function runTests() {
   }
 }
 
-runTests(); 
+// XML Preservation Tests
+function runXmlPreservationTests() {
+  console.log('\n=== XML Preservation Tests ===\n');
+  
+  const xmlTests = [
+    {
+      name: 'Preserve XML plist tags',
+      input: '```xml\n<dict><key>test</key><string>value</string></dict>\n```',
+      shouldHave: ['<dict>', '<key>test</key>', '<string>value</string>'],
+      shouldNotHave: []
+    },
+    {
+      name: 'Remove HTML but keep XML',
+      input: 'Text with <strong>bold</strong>\n```xml\n<plist><dict></dict></plist>\n```',
+      shouldHave: ['<plist>', '<dict>'],
+      shouldNotHave: ['<strong>']
+    }
+  ];
+  
+  let xmlPassCount = 0;
+  xmlTests.forEach((test, i) => {
+    const cleaned = cleanMarkdownContent(test.input);
+    const hasAll = test.shouldHave.every(tag => cleaned.includes(tag));
+    const hasNone = test.shouldNotHave.every(tag => !cleaned.includes(tag));
+    
+    if (hasAll && hasNone) {
+      console.log(`✅ XML Test ${i + 1}: ${test.name}`);
+      xmlPassCount++;
+    } else {
+      console.log(`❌ XML Test ${i + 1}: ${test.name}`);
+    }
+  });
+  
+  console.log(`\nXML Tests: ${xmlPassCount}/${xmlTests.length} passed\n`);
+}
+
+runTests();
+runXmlPreservationTests(); 


### PR DESCRIPTION
The previous implementation was too aggressive in removing ALL tags with /<[^>]*>/g, which stripped important XML content like plist tags (<key>, <string>, <dict>, etc.) from code blocks. This fix makes the tag removal more selective by targeting only common HTML formatting tags while preserving XML content.

Changes:
- Modified cleanMarkdownContent() to use selective regex for HTML tag removal
- Added XML preservation tests to verify plist tags are kept while HTML is removed
- Verified fix works with Santa docs - XML plist content now properly preserved

🤖 Generated with [Claude Code](https://claude.ai/code)