### PR TITLE
Refactor/Fix: Use suffix-based route matching for accurate URL resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ module.exports = {
 
 ### Path Transformation Examples
 
+> **Note:** The plugin now resolves URLs by matching file paths against Docusaurus's actual routes (provided via the `postBuild` hook). Path transformations are only applied as a **fallback** when a file cannot be matched to a known route. In most configurations, you do not need `pathTransformation` at all.
+
 The path transformation feature allows you to manipulate how URLs are constructed from file paths:
 
 **Example 1**: Remove 'docs' from the URL path
@@ -1082,19 +1084,15 @@ The plugin:
 2. Optionally includes blog content
 3. Orders documents according to specified glob patterns (if provided)
 4. Extracts metadata, titles, and content from each file
-5. Creates proper URL links to each document section
-6. Applies path transformations according to configuration (removing or adding path segments)
-7. Generates a table of contents in `llms.txt`
-8. Combines all documentation content in `llms-full.txt`
-9. Creates custom LLM files based on specified configurations
-10. Provides statistics about the generated documentation
+5. Resolves each file's URL by suffix-matching against Docusaurus's known routes, falling back to path-based URL construction with optional path transformations
+6. Generates a table of contents in `llms.txt`
+7. Combines all documentation content in `llms-full.txt`
+8. Creates custom LLM files based on specified configurations
+9. Provides statistics about the generated documentation
 
 ## Testing
 
-The plugin includes comprehensive tests in the `tests` directory:
-
-- **Unit tests**: Test the path transformation functionality in isolation
-- **Integration tests**: Simulate a Docusaurus build with various configurations
+The plugin includes comprehensive tests in the `tests` directory covering route resolution, path transformation, content cleaning, error handling, and more.
 
 To run the tests:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  */
 
 import * as path from 'path';
-import type { LoadContext, Plugin, Props, RouteConfig } from '@docusaurus/types';
+import type { LoadContext, Plugin, Props } from '@docusaurus/types';
 import { PluginOptions, PluginContext, CustomLLMFile } from './types';
 import { collectDocFiles, generateStandardLLMFiles, generateCustomLLMFiles } from './generator';
 import { setLogLevel, LogLevel, logger, getErrorMessage, isDefined, isNonEmptyString, isNonEmptyArray } from './utils';
@@ -292,35 +292,12 @@ export default function docusaurusPluginLLMs(
       try {
         let enhancedContext = pluginContext;
         
-        // If props are provided (Docusaurus 3.x+), use the resolved routes
-        if (props?.routes) {
-          // Create a map of file paths to their resolved URLs
-          const routeMap = new Map<string, string>();
-          
-          // Helper function to recursively process routes
-          const processRoutes = (routes: RouteConfig[]) => {
-            routes.forEach(route => {
-              if (route.path) {
-                // Store the actual resolved path
-                routeMap.set(route.path, route.path);
-              }
-              
-              // Process nested routes recursively
-              if (route.routes) {
-                processRoutes(route.routes);
-              }
-            });
-          };
-          
-          // Process all routes (cast to RouteConfig[] for recursive processing)
-          processRoutes(props.routes as RouteConfig[]);
-          
-          // Pass the resolved routes to the plugin context
+        // If props are provided (Docusaurus 3.x+), pass the resolved route
+        // paths so route resolution can match files to their actual URLs
+        if (props?.routesPaths) {
           enhancedContext = {
             ...pluginContext,
             routesPaths: props.routesPaths,
-            routes: props.routes,
-            routeMap,
           };
         }
         

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -231,6 +231,29 @@ export async function processMarkdownFile(
 }
 
 /**
+ * Find the best matching route for a given path tail using suffix matching.
+ * This avoids needing to know about version prefixes, baseUrl, or other
+ * routing details — any route ending with the tail is a match.
+ * When multiple routes match, the shortest is preferred (typically the
+ * stable/non-versioned route over a versioned one like /nightly/...).
+ */
+function findMatchingRoute(
+  routesPaths: string[],
+  tail: string
+): string | undefined {
+  const normalized = tail.toLowerCase().replace(/\/+$/, '');
+  if (!normalized) return undefined;
+
+  const matches = routesPaths.filter(route => {
+    const r = route.toLowerCase().replace(/\/+$/, '');
+    return r === `/${normalized}` || r.endsWith(`/${normalized}`);
+  });
+
+  if (matches.length <= 1) return matches[0];
+  return matches.sort((a, b) => a.length - b.length)[0];
+}
+
+/**
  * Collapse a trailing segment that matches its parent directory name.
  * Docusaurus treats such files as directory indices
  * (e.g. "generics/generics" → "generics", "API/API" → "API").
@@ -250,218 +273,71 @@ function collapseMatchingTrailingSegment(urlPath: string): string {
 /**
  * Remove numbered prefixes from path segments (e.g., "01-intro" -> "intro")
  */
-function removeNumberedPrefixes(path: string): string {
-  return path.split('/').map(segment => {
-    // Remove numbered prefixes like "01-", "1-", "001-" from each segment
+function removeNumberedPrefixes(pathStr: string): string {
+  return pathStr.split('/').map(segment => {
     return segment.replace(/^\d+-/, '');
   }).join('/');
 }
 
 /**
- * Try to find a route in the route map from a list of possible paths
- */
-function findRouteInMap(routeMap: Map<string, string>, possiblePaths: string[]): string | undefined {
-  for (const possiblePath of possiblePaths) {
-    const route = routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-    if (route) {
-      return route;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Try exact match for route resolution
- */
-function tryExactRouteMatch(
-  routeMap: Map<string, string>,
-  relativePath: string,
-  pathPrefix: string
-): string | undefined {
-  const possiblePaths = [
-    `/${pathPrefix}/${relativePath}`,
-    `/${relativePath}`,
-  ];
-  return findRouteInMap(routeMap, possiblePaths);
-}
-
-/**
- * Try route resolution with numbered prefix removal
- */
-function tryNumberedPrefixResolution(
-  routeMap: Map<string, string>,
-  relativePath: string,
-  pathPrefix: string
-): string | undefined {
-  const cleanPath = removeNumberedPrefixes(relativePath);
-
-  // Try basic cleaned path
-  const basicPaths = [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`];
-  const basicMatch = findRouteInMap(routeMap, basicPaths);
-  if (basicMatch) {
-    return basicMatch;
-  }
-
-  // Try nested folder structures with numbered prefixes at different levels
-  const segments = relativePath.split('/');
-  if (segments.length > 1) {
-    for (let i = 0; i < segments.length; i++) {
-      const modifiedSegments = [...segments];
-      modifiedSegments[i] = modifiedSegments[i].replace(/^\d+-/, '');
-      const modifiedPath = modifiedSegments.join('/');
-      const pathsToTry = [`/${pathPrefix}/${modifiedPath}`, `/${modifiedPath}`];
-
-      const match = findRouteInMap(routeMap, pathsToTry);
-      if (match) {
-        return match;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Try finding best match using routes paths array
- */
-function tryRoutesPathsMatch(
-  routesPaths: string[],
-  relativePath: string,
-  pathPrefix: string
-): string | undefined {
-  const cleanPath = removeNumberedPrefixes(relativePath);
-  const normalizedCleanPath = cleanPath.toLowerCase().replace(/\/+$/, '');
-
-  // Also try with directory-collapsed variant
-  const collapsedCleanPath = collapseMatchingTrailingSegment(normalizedCleanPath);
-  const candidates = [normalizedCleanPath];
-  if (collapsedCleanPath !== normalizedCleanPath) {
-    candidates.push(collapsedCleanPath);
-  }
-
-  return routesPaths.find(routePath => {
-    const normalizedRoute = routePath.toLowerCase().replace(/\/+$/, '');
-    return candidates.some(candidate =>
-      normalizedRoute.endsWith(`/${candidate}`) ||
-      normalizedRoute === `/${pathPrefix}/${candidate}` ||
-      normalizedRoute === `/${candidate}`
-    );
-  });
-}
-
-/**
- * Resolve the URL for a document using Docusaurus routes
- * @param filePath - Full path to the file
- * @param baseDir - Base directory (typically siteDir)
- * @param pathPrefix - Path prefix ('docs' or 'blog')
- * @param context - Plugin context with route map
- * @returns Resolved URL or undefined if not found
+ * Resolve the URL for a document by matching its file path against
+ * Docusaurus's resolved routes using suffix matching.
+ *
+ * The approach: strip the docsDir prefix and file extension to get a "tail"
+ * (e.g. "docs/manual/get-started"), then find any route ending with that
+ * tail. This naturally handles version prefixes (/nightly/...), custom
+ * baseUrl, and routeBasePath without needing to know about them.
+ *
+ * Falls back to reading frontmatter when the file's `id` or `slug` differs
+ * from its filename (e.g. python_to_mojo.mdx with id: python-to-mojo).
  */
 async function resolveDocumentUrl(
   filePath: string,
   baseDir: string,
-  pathPrefix: string,
   context: PluginContext
 ): Promise<string | undefined> {
-  // Early return if no route map available
-  if (!context.routeMap) {
-    return undefined;
-  }
+  if (!context.routesPaths?.length) return undefined;
 
-  // Convert file path to a potential route path
-  const relativePath = normalizePath(path.relative(baseDir, filePath))
+  const { docsDir } = context;
+
+  const relative = normalizePath(path.relative(baseDir, filePath))
     .replace(/\.mdx?$/, '')
     .replace(/\/index$/, '');
 
-  // Try exact match first (respects Docusaurus's resolved routes)
-  const exactMatch = tryExactRouteMatch(context.routeMap, relativePath, pathPrefix);
-  if (exactMatch) {
-    return exactMatch;
+  // Strip the docsDir prefix — docsDir is the filesystem root for the docs
+  // plugin, which Docusaurus removes when computing routes
+  let tail = relative;
+  if (docsDir && tail.startsWith(`${docsDir}/`)) {
+    tail = tail.substring(`${docsDir}/`.length);
   }
 
-  // Try numbered prefix removal as fallback
-  const prefixMatch = tryNumberedPrefixResolution(context.routeMap, relativePath, pathPrefix);
-  if (prefixMatch) {
-    return prefixMatch;
+  // Build candidate tails: original, directory-collapsed, numbered-prefix-stripped
+  const tails = new Set<string>([tail]);
+
+  const collapsed = collapseMatchingTrailingSegment(tail);
+  if (collapsed !== tail) tails.add(collapsed);
+
+  const stripped = removeNumberedPrefixes(tail);
+  if (stripped !== tail) tails.add(stripped);
+
+  for (const t of tails) {
+    const match = findMatchingRoute(context.routesPaths, t);
+    if (match) return match;
   }
 
-  // When baseDir is siteDir, relativePath includes the docsDir prefix (e.g.
-  // "docs/docs/manual/get-started" for a file at siteDir/docs/docs/manual/get-started.mdx).
-  // The first "docs/" is the docsDir root which Docusaurus strips when computing routes,
-  // so we need to try lookups without it.
-  const { docsDir } = context;
-  const withoutDocsDir = (docsDir && relativePath.startsWith(`${docsDir}/`))
-    ? relativePath.substring(`${docsDir}/`.length)
-    : null;
-
-  // Build a list of candidate paths to try: the original relativePath, the
-  // docsDir-stripped variant, and directory-collapsed variants of each.
-  // Docusaurus treats a file as the directory index when its name matches the
-  // parent directory (e.g. generics/generics.mdx → /generics/).
-  const candidates: string[] = [relativePath];
-  if (withoutDocsDir) {
-    candidates.push(withoutDocsDir);
-  }
-
-  const allCandidates = [...candidates];
-  for (const candidate of candidates) {
-    const collapsed = collapseMatchingTrailingSegment(candidate);
-    if (collapsed !== candidate) {
-      allCandidates.push(collapsed);
-    }
-  }
-
-  for (const candidate of allCandidates) {
-    const exact = tryExactRouteMatch(context.routeMap, candidate, pathPrefix);
-    if (exact) return exact;
-
-    const prefix = tryNumberedPrefixResolution(context.routeMap, candidate, pathPrefix);
-    if (prefix) return prefix;
-  }
-
-  // Try to find the best match using the routesPaths array
-  if (context.routesPaths) {
-    for (const candidate of allCandidates) {
-      const match = tryRoutesPathsMatch(context.routesPaths, candidate, pathPrefix);
-      if (match) return match;
-    }
-  }
-
-  // When frontmatter `id` or `slug` differs from the filename, the path-based
-  // lookups above will miss. Read frontmatter and retry with the overridden slug.
+  // When frontmatter `id` or `slug` differs from the filename, the
+  // path-based lookups above will miss. Read frontmatter and retry.
   try {
     const content = await readFile(filePath);
     const { data } = matter(content);
-    const fmSlug = isNonEmptyString(data.slug) ? data.slug.replace(/^\/+|\/+$/g, '') : null;
-    const fmId = isNonEmptyString(data.id) ? data.id.replace(/^\/+|\/+$/g, '') : null;
 
-    if (fmSlug || fmId) {
-      const parentDir = normalizePath(path.dirname(relativePath));
-      const fmCandidates: string[] = [];
-
-      for (const override of [fmSlug, fmId]) {
-        if (!override) continue;
-        // Replace the last path segment with the frontmatter override
-        const overriddenPath = parentDir === '.' ? override : `${parentDir}/${override}`;
-        fmCandidates.push(overriddenPath);
-
-        // Also try with docsDir stripped
-        if (docsDir && overriddenPath.startsWith(`${docsDir}/`)) {
-          fmCandidates.push(overriddenPath.substring(`${docsDir}/`.length));
-        }
-      }
-
-      for (const candidate of fmCandidates) {
-        const exact = tryExactRouteMatch(context.routeMap, candidate, pathPrefix);
-        if (exact) return exact;
-      }
-
-      if (context.routesPaths) {
-        for (const candidate of fmCandidates) {
-          const match = tryRoutesPathsMatch(context.routesPaths, candidate, pathPrefix);
-          if (match) return match;
-        }
-      }
+    for (const override of [data.slug, data.id]) {
+      if (!isNonEmptyString(override)) continue;
+      const slug = override.replace(/^\/+|\/+$/g, '');
+      const parentDir = path.dirname(tail);
+      const overriddenTail = parentDir === '.' ? slug : `${parentDir}/${slug}`;
+      const match = findMatchingRoute(context.routesPaths, overriddenTail);
+      if (match) return match;
     }
   } catch {
     // Frontmatter read failed; fall through
@@ -572,23 +448,14 @@ export async function processFilesWithPatterns(
   const results = await Promise.allSettled(
     filesToProcess.map(async (filePath) => {
       try {
-        // Determine if this is a blog or docs file
-        const isBlogFile = filePath.includes(path.join(siteDir, 'blog'));
-        // Use siteDir as baseDir to preserve full directory structure (docs/path/file.md instead of just path/file.md)
         const baseDir = siteDir;
+        const isBlogFile = filePath.includes(path.join(siteDir, 'blog'));
         const pathPrefix = isBlogFile ? 'blog' : 'docs';
 
-        // Try to find the resolved URL for this file from the route map
-        const resolvedUrl = await resolveDocumentUrl(filePath, baseDir, pathPrefix, context);
+        const resolvedUrl = await resolveDocumentUrl(filePath, baseDir, context);
 
-        // Log when we successfully resolve a URL using Docusaurus routes
-        if (resolvedUrl && context.routeMap) {
-          const relativePath = normalizePath(path.relative(baseDir, filePath))
-            .replace(/\.mdx?$/, '')
-            .replace(/\/index$/, '');
-          if (resolvedUrl !== `/${pathPrefix}/${relativePath}`) {
-            logger.verbose(`Resolved URL for ${path.basename(filePath)}: ${resolvedUrl} (was: /${pathPrefix}/${relativePath})`);
-          }
+        if (resolvedUrl) {
+          logger.verbose(`Resolved URL for ${path.basename(filePath)}: ${resolvedUrl}`);
         }
 
         const docInfo = await processMarkdownFile(

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -231,6 +231,23 @@ export async function processMarkdownFile(
 }
 
 /**
+ * Collapse a trailing segment that matches its parent directory name.
+ * Docusaurus treats such files as directory indices
+ * (e.g. "generics/generics" → "generics", "API/API" → "API").
+ */
+function collapseMatchingTrailingSegment(urlPath: string): string {
+  const segments = urlPath.split('/');
+  if (segments.length >= 2) {
+    const last = segments[segments.length - 1];
+    const parent = segments[segments.length - 2];
+    if (last.toLowerCase() === parent.toLowerCase()) {
+      return segments.slice(0, -1).join('/');
+    }
+  }
+  return urlPath;
+}
+
+/**
  * Remove numbered prefixes from path segments (e.g., "01-intro" -> "intro")
  */
 function removeNumberedPrefixes(path: string): string {
@@ -313,13 +330,22 @@ function tryRoutesPathsMatch(
   pathPrefix: string
 ): string | undefined {
   const cleanPath = removeNumberedPrefixes(relativePath);
-  const normalizedCleanPath = cleanPath.toLowerCase();
+  const normalizedCleanPath = cleanPath.toLowerCase().replace(/\/+$/, '');
+
+  // Also try with directory-collapsed variant
+  const collapsedCleanPath = collapseMatchingTrailingSegment(normalizedCleanPath);
+  const candidates = [normalizedCleanPath];
+  if (collapsedCleanPath !== normalizedCleanPath) {
+    candidates.push(collapsedCleanPath);
+  }
 
   return routesPaths.find(routePath => {
-    const normalizedRoute = routePath.toLowerCase();
-    return normalizedRoute.endsWith(`/${normalizedCleanPath}`) ||
-           normalizedRoute === `/${pathPrefix}/${normalizedCleanPath}` ||
-           normalizedRoute === `/${normalizedCleanPath}`;
+    const normalizedRoute = routePath.toLowerCase().replace(/\/+$/, '');
+    return candidates.some(candidate =>
+      normalizedRoute.endsWith(`/${candidate}`) ||
+      normalizedRoute === `/${pathPrefix}/${candidate}` ||
+      normalizedRoute === `/${candidate}`
+    );
   });
 }
 
@@ -331,12 +357,12 @@ function tryRoutesPathsMatch(
  * @param context - Plugin context with route map
  * @returns Resolved URL or undefined if not found
  */
-function resolveDocumentUrl(
+async function resolveDocumentUrl(
   filePath: string,
   baseDir: string,
   pathPrefix: string,
   context: PluginContext
-): string | undefined {
+): Promise<string | undefined> {
   // Early return if no route map available
   if (!context.routeMap) {
     return undefined;
@@ -359,9 +385,86 @@ function resolveDocumentUrl(
     return prefixMatch;
   }
 
+  // When baseDir is siteDir, relativePath includes the docsDir prefix (e.g.
+  // "docs/docs/manual/get-started" for a file at siteDir/docs/docs/manual/get-started.mdx).
+  // The first "docs/" is the docsDir root which Docusaurus strips when computing routes,
+  // so we need to try lookups without it.
+  const { docsDir } = context;
+  const withoutDocsDir = (docsDir && relativePath.startsWith(`${docsDir}/`))
+    ? relativePath.substring(`${docsDir}/`.length)
+    : null;
+
+  // Build a list of candidate paths to try: the original relativePath, the
+  // docsDir-stripped variant, and directory-collapsed variants of each.
+  // Docusaurus treats a file as the directory index when its name matches the
+  // parent directory (e.g. generics/generics.mdx → /generics/).
+  const candidates: string[] = [relativePath];
+  if (withoutDocsDir) {
+    candidates.push(withoutDocsDir);
+  }
+
+  const allCandidates = [...candidates];
+  for (const candidate of candidates) {
+    const collapsed = collapseMatchingTrailingSegment(candidate);
+    if (collapsed !== candidate) {
+      allCandidates.push(collapsed);
+    }
+  }
+
+  for (const candidate of allCandidates) {
+    const exact = tryExactRouteMatch(context.routeMap, candidate, pathPrefix);
+    if (exact) return exact;
+
+    const prefix = tryNumberedPrefixResolution(context.routeMap, candidate, pathPrefix);
+    if (prefix) return prefix;
+  }
+
   // Try to find the best match using the routesPaths array
   if (context.routesPaths) {
-    return tryRoutesPathsMatch(context.routesPaths, relativePath, pathPrefix);
+    for (const candidate of allCandidates) {
+      const match = tryRoutesPathsMatch(context.routesPaths, candidate, pathPrefix);
+      if (match) return match;
+    }
+  }
+
+  // When frontmatter `id` or `slug` differs from the filename, the path-based
+  // lookups above will miss. Read frontmatter and retry with the overridden slug.
+  try {
+    const content = await readFile(filePath);
+    const { data } = matter(content);
+    const fmSlug = isNonEmptyString(data.slug) ? data.slug.replace(/^\/+|\/+$/g, '') : null;
+    const fmId = isNonEmptyString(data.id) ? data.id.replace(/^\/+|\/+$/g, '') : null;
+
+    if (fmSlug || fmId) {
+      const parentDir = normalizePath(path.dirname(relativePath));
+      const fmCandidates: string[] = [];
+
+      for (const override of [fmSlug, fmId]) {
+        if (!override) continue;
+        // Replace the last path segment with the frontmatter override
+        const overriddenPath = parentDir === '.' ? override : `${parentDir}/${override}`;
+        fmCandidates.push(overriddenPath);
+
+        // Also try with docsDir stripped
+        if (docsDir && overriddenPath.startsWith(`${docsDir}/`)) {
+          fmCandidates.push(overriddenPath.substring(`${docsDir}/`.length));
+        }
+      }
+
+      for (const candidate of fmCandidates) {
+        const exact = tryExactRouteMatch(context.routeMap, candidate, pathPrefix);
+        if (exact) return exact;
+      }
+
+      if (context.routesPaths) {
+        for (const candidate of fmCandidates) {
+          const match = tryRoutesPathsMatch(context.routesPaths, candidate, pathPrefix);
+          if (match) return match;
+        }
+      }
+    }
+  } catch {
+    // Frontmatter read failed; fall through
   }
 
   return undefined;
@@ -476,7 +579,7 @@ export async function processFilesWithPatterns(
         const pathPrefix = isBlogFile ? 'blog' : 'docs';
 
         // Try to find the resolved URL for this file from the route map
-        const resolvedUrl = resolveDocumentUrl(filePath, baseDir, pathPrefix, context);
+        const resolvedUrl = await resolveDocumentUrl(filePath, baseDir, pathPrefix, context);
 
         // Log when we successfully resolve a URL using Docusaurus routes
         if (resolvedUrl && context.routeMap) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,6 @@
  * Type definitions for the docusaurus-plugin-llms plugin
  */
 
-import type { LoadContext, RouteConfig } from '@docusaurus/types';
-
 /**
  * Interface for processed document information
  */
@@ -148,6 +146,4 @@ export interface PluginContext {
   docDescription: string;
   options: PluginOptions;
   routesPaths?: string[];
-  routes?: RouteConfig[];
-  routeMap?: Map<string, string>;
 } 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,108 +1,129 @@
 # Testing the docusaurus-plugin-llms
 
-This document provides guidance on how to test the Docusaurus plugin, particularly the path transformation features.
+## Running Tests
 
-## Unit Testing
-
-We've provided two test scripts you can run to test the plugin functionality:
-
-1. `tests/test-path-transforms.js` - Unit tests for the path transformation function
-2. `tests/test-path-transformation.js` - Integration tests that simulate a Docusaurus build
-
-### Running Unit Tests
-
-To test just the path transformation logic:
+Run the full test suite (build + unit + integration):
 
 ```bash
-node tests/test-path-transforms.js
+npm test
 ```
 
-This will run a series of test cases against the path transformation function and verify the results.
-
-### Running Integration Tests
-
-To run the integration tests that simulate a Docusaurus build:
+Or run individual stages:
 
 ```bash
-# Build the plugin first
-npm run build
-
-# Then run the tests
-node tests/test-path-transformation.js
+npm run build            # Compile TypeScript
+npm run test:unit        # Unit tests only
+npm run test:integration # Integration tests only
 ```
 
-This creates a test directory structure, runs the plugin with various configurations, and outputs the results for verification.
+### Standalone Test Files
+
+Some test files are not included in `npm run test:unit` but can be run directly:
+
+```bash
+node tests/test-route-resolution-helpers.js   # Route resolution integration tests
+node tests/test-refactored-route-helpers.js   # Suffix-matching unit tests
+node tests/test-numbered-prefixes.js          # Numbered prefix handling
+```
+
+## Test Categories
+
+### Route Resolution (`test-route-resolution-helpers.js`)
+
+Integration tests that exercise `processFilesWithPatterns` end-to-end with
+real files on disk. Covers:
+
+- **Suffix-based matching** — files resolve to routes via `routesPaths`
+- **Numbered prefix stripping** — `01-intro.md` matches `/intro`
+- **docsDir stripping** (Issue #31) — prevents doubled `docs/docs/` paths
+  when `routeBasePath: '/'`
+- **Trailing-slash routes** (Issue #30) — routes like `/intro/` match correctly
+- **Directory collapsing** — `generics/generics.md` resolves to `/generics`
+- **Frontmatter overrides** — files with `id` or `slug` in frontmatter
+  resolve correctly when the filename differs from the route
+- **Versioned route disambiguation** — shortest route (stable) preferred
+  over versioned (`/nightly/...`)
+- **Fallback** — graceful path-based URL construction when `routesPaths`
+  is not available
+
+### Route Helpers (`test-refactored-route-helpers.js`)
+
+Unit tests for the individual helper functions used by route resolution:
+
+- `findMatchingRoute` — suffix matching, edge cases, shortest-match preference
+- `collapseMatchingTrailingSegment` — directory index collapsing
+- `removeNumberedPrefixes` — `01-category/02-file` → `category/file`
+- Path normalization — extension removal, index handling, Windows paths
+- URL construction — `new URL()` with various `siteUrl` formats
+
+### Numbered Prefixes (`test-numbered-prefixes.js`)
+
+Focused tests for numbered prefix scenarios: exact match priority,
+fallback to prefix removal, multi-level nesting, mixed segments,
+trailing slashes, and versioned route disambiguation.
+
+### Path Transformation (`test-path-transforms.js`, `test-path-transformation.js`)
+
+Tests for the `pathTransformation` option (`ignorePaths`, `addPaths`).
+
+### Other Tests
+
+The `test:unit` script runs ~27 additional test files covering:
+
+- Plugin option validation and input sanitization
+- Markdown processing (import removal, header deduplication, partials)
+- File I/O error handling, BOM detection, circular import detection
+- URL encoding, filename sanitization, regex safety
+- Batch/parallel processing, path length validation
 
 ## Testing in a Real Docusaurus Project
 
 To test the plugin in a real Docusaurus project:
 
-1. **Create a new Docusaurus site**:
+1. **Link or reference your local plugin**:
 
-   ```bash
-   npx @docusaurus/init@latest init my-test-site classic
-   cd my-test-site
+   In your Docusaurus project's `package.json`:
+   ```json
+   "docusaurus-plugin-llms": "file:/path/to/docusaurus-plugin-llms"
    ```
 
-2. **Link your plugin for local development**:
+   Then run `npm install`.
 
-   From your plugin directory:
-   ```bash
-   npm link
-   ```
-
-   From your Docusaurus project:
-   ```bash
-   npm link docusaurus-plugin-llms
-   ```
-
-3. **Add the plugin to your docusaurus.config.js**:
+2. **Add the plugin to `docusaurus.config.js`**:
 
    ```js
-   module.exports = {
-     // ... other config
-     plugins: [
-       [
-         'docusaurus-plugin-llms',
-         {
-           // Test your path transformation options
-           pathTransformation: {
-             ignorePaths: ['api'],
-             addPaths: ['reference'],
-           },
-         },
-       ],
+   plugins: [
+     [
+       'docusaurus-plugin-llms',
+       {
+         title: 'My Documentation',
+         description: 'Description of the docs.',
+         excludeImports: true,
+         removeDuplicateHeadings: true,
+       },
      ],
-   };
+   ],
    ```
 
-4. **Build the Docusaurus site**:
+3. **Build and inspect**:
 
    ```bash
    npm run build
    ```
 
-5. **Check the output**:
+   Check `build/llms.txt` and verify that URLs match your site's actual routes.
 
-   After building, check the `build` directory for the generated `llms.txt` and `llms-full.txt` files. Verify that the URLs are transformed according to your configuration.
+## How Route Resolution Works
 
-## Verifying URL Transformations
+The plugin resolves file paths to URLs using suffix-based matching against
+Docusaurus's `routesPaths` (provided in the `postBuild` hook). This avoids
+needing to know about `routeBasePath`, version prefixes, or `baseUrl` — any
+route ending with the file's path tail is a match.
 
-When testing path transformations, verify that:
-
-1. **ignorePaths**: Path segments specified are removed from the URLs
-2. **addPaths**: Path segments are added to the URLs when they don't already exist
-3. **Combined transformations**: Both operations work correctly together
-
-Example paths to test:
-
-- `docs/getting-started.md` → should become → `getting-started` (with ignorePaths: ['docs'])
-- `docs/api/method.md` → should become → `reference/api/method` (with ignorePaths: ['docs'], addPaths: ['reference'])
-
-## Troubleshooting
-
-If you encounter issues with path transformations:
-
-1. Check the regex in the `applyPathTransformations` function
-2. Verify that the path segments are properly formatted (no leading/trailing slashes)
-3. Run the unit tests to isolate potential issues 
+Resolution order:
+1. Strip `docsDir` prefix and file extension to get a "tail"
+2. Try suffix match against `routesPaths` (original tail)
+3. Try directory-collapsed tail (`generics/generics` → `generics`)
+4. Try numbered-prefix-stripped tail (`01-intro` → `intro`)
+5. Read frontmatter `slug`/`id` and retry suffix match
+6. Fall back to path-based URL construction

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,129 +1,132 @@
 # Testing the docusaurus-plugin-llms
 
-## Running Tests
+This document provides guidance on how to test the Docusaurus plugin.
 
-Run the full test suite (build + unit + integration):
+## Running All Tests
+
+The quickest way to run the full test suite (build + unit + integration):
 
 ```bash
 npm test
 ```
 
-Or run individual stages:
+## Unit Testing
+
+### Path Transformation
+
+1. `tests/test-path-transforms.js` - Unit tests for the path transformation function
+2. `tests/test-path-transformation.js` - Integration tests that simulate a Docusaurus build
+
+To test just the path transformation logic:
 
 ```bash
-npm run build            # Compile TypeScript
-npm run test:unit        # Unit tests only
-npm run test:integration # Integration tests only
+node tests/test-path-transforms.js
 ```
 
-### Standalone Test Files
+This will run a series of test cases against the path transformation function and verify the results.
 
-Some test files are not included in `npm run test:unit` but can be run directly:
+### Running Integration Tests
+
+To run the integration tests that simulate a Docusaurus build:
 
 ```bash
-node tests/test-route-resolution-helpers.js   # Route resolution integration tests
-node tests/test-refactored-route-helpers.js   # Suffix-matching unit tests
-node tests/test-numbered-prefixes.js          # Numbered prefix handling
+# Build the plugin first
+npm run build
+
+# Then run the tests
+node tests/test-path-transformation.js
 ```
 
-## Test Categories
+This creates a test directory structure, runs the plugin with various configurations, and outputs the results for verification.
 
-### Route Resolution (`test-route-resolution-helpers.js`)
+### Route Resolution
 
-Integration tests that exercise `processFilesWithPatterns` end-to-end with
-real files on disk. Covers:
+The plugin resolves file paths to URLs using suffix-based matching against Docusaurus's `routesPaths`. The following test files cover this behavior:
 
-- **Suffix-based matching** — files resolve to routes via `routesPaths`
-- **Numbered prefix stripping** — `01-intro.md` matches `/intro`
-- **docsDir stripping** (Issue #31) — prevents doubled `docs/docs/` paths
-  when `routeBasePath: '/'`
-- **Trailing-slash routes** (Issue #30) — routes like `/intro/` match correctly
-- **Directory collapsing** — `generics/generics.md` resolves to `/generics`
-- **Frontmatter overrides** — files with `id` or `slug` in frontmatter
-  resolve correctly when the filename differs from the route
-- **Versioned route disambiguation** — shortest route (stable) preferred
-  over versioned (`/nightly/...`)
-- **Fallback** — graceful path-based URL construction when `routesPaths`
-  is not available
+1. `tests/test-route-resolution-helpers.js` - Integration tests through `processFilesWithPatterns`, including regression tests for issues #30 (trailing slash) and #31 (doubled `docs/docs/` paths)
+2. `tests/test-refactored-route-helpers.js` - Unit tests for suffix matching, directory collapsing, and numbered prefix removal
+3. `tests/test-numbered-prefixes.js` - Focused tests for numbered prefix scenarios
 
-### Route Helpers (`test-refactored-route-helpers.js`)
+These are standalone test files not included in `npm run test:unit`. Run them directly:
 
-Unit tests for the individual helper functions used by route resolution:
-
-- `findMatchingRoute` — suffix matching, edge cases, shortest-match preference
-- `collapseMatchingTrailingSegment` — directory index collapsing
-- `removeNumberedPrefixes` — `01-category/02-file` → `category/file`
-- Path normalization — extension removal, index handling, Windows paths
-- URL construction — `new URL()` with various `siteUrl` formats
-
-### Numbered Prefixes (`test-numbered-prefixes.js`)
-
-Focused tests for numbered prefix scenarios: exact match priority,
-fallback to prefix removal, multi-level nesting, mixed segments,
-trailing slashes, and versioned route disambiguation.
-
-### Path Transformation (`test-path-transforms.js`, `test-path-transformation.js`)
-
-Tests for the `pathTransformation` option (`ignorePaths`, `addPaths`).
-
-### Other Tests
-
-The `test:unit` script runs ~27 additional test files covering:
-
-- Plugin option validation and input sanitization
-- Markdown processing (import removal, header deduplication, partials)
-- File I/O error handling, BOM detection, circular import detection
-- URL encoding, filename sanitization, regex safety
-- Batch/parallel processing, path length validation
+```bash
+node tests/test-route-resolution-helpers.js
+node tests/test-refactored-route-helpers.js
+node tests/test-numbered-prefixes.js
+```
 
 ## Testing in a Real Docusaurus Project
 
 To test the plugin in a real Docusaurus project:
 
-1. **Link or reference your local plugin**:
+1. **Create a new Docusaurus site**:
 
-   In your Docusaurus project's `package.json`:
-   ```json
-   "docusaurus-plugin-llms": "file:/path/to/docusaurus-plugin-llms"
+   ```bash
+   npx @docusaurus/init@latest init my-test-site classic
+   cd my-test-site
    ```
 
-   Then run `npm install`.
+2. **Link your plugin for local development**:
 
-2. **Add the plugin to `docusaurus.config.js`**:
+   From your plugin directory:
+   ```bash
+   npm link
+   ```
+
+   From your Docusaurus project:
+   ```bash
+   npm link docusaurus-plugin-llms
+   ```
+
+3. **Add the plugin to your docusaurus.config.js**:
 
    ```js
-   plugins: [
-     [
-       'docusaurus-plugin-llms',
-       {
-         title: 'My Documentation',
-         description: 'Description of the docs.',
-         excludeImports: true,
-         removeDuplicateHeadings: true,
-       },
+   module.exports = {
+     // ... other config
+     plugins: [
+       [
+         'docusaurus-plugin-llms',
+         {
+           // Test your path transformation options
+           pathTransformation: {
+             ignorePaths: ['api'],
+             addPaths: ['reference'],
+           },
+         },
+       ],
      ],
-   ],
+   };
    ```
 
-3. **Build and inspect**:
+4. **Build the Docusaurus site**:
 
    ```bash
    npm run build
    ```
 
-   Check `build/llms.txt` and verify that URLs match your site's actual routes.
+5. **Check the output**:
 
-## How Route Resolution Works
+   After building, check the `build` directory for the generated `llms.txt` and `llms-full.txt` files. Verify that the URLs are transformed according to your configuration.
 
-The plugin resolves file paths to URLs using suffix-based matching against
-Docusaurus's `routesPaths` (provided in the `postBuild` hook). This avoids
-needing to know about `routeBasePath`, version prefixes, or `baseUrl` — any
-route ending with the file's path tail is a match.
+## Verifying URL Transformations
 
-Resolution order:
-1. Strip `docsDir` prefix and file extension to get a "tail"
-2. Try suffix match against `routesPaths` (original tail)
-3. Try directory-collapsed tail (`generics/generics` → `generics`)
-4. Try numbered-prefix-stripped tail (`01-intro` → `intro`)
-5. Read frontmatter `slug`/`id` and retry suffix match
-6. Fall back to path-based URL construction
+> **Note:** Path transformations are now only applied as a fallback when a file cannot be matched to a known Docusaurus route. In most configurations, URLs are resolved automatically via suffix-based route matching.
+
+When testing path transformations, verify that:
+
+1. **ignorePaths**: Path segments specified are removed from the URLs
+2. **addPaths**: Path segments are added to the URLs when they don't already exist
+3. **Combined transformations**: Both operations work correctly together
+
+Example paths to test:
+
+- `docs/getting-started.md` → should become → `getting-started` (with ignorePaths: ['docs'])
+- `docs/api/method.md` → should become → `reference/api/method` (with ignorePaths: ['docs'], addPaths: ['reference'])
+
+## Troubleshooting
+
+If you encounter issues with path transformations:
+
+1. Check the regex in the `applyPathTransformations` function
+2. Verify that the path segments are properly formatted (no leading/trailing slashes)
+3. Run the unit tests to isolate potential issues 

--- a/tests/test-numbered-prefixes.js
+++ b/tests/test-numbered-prefixes.js
@@ -1,86 +1,59 @@
 /**
- * Unit tests for numbered prefix route resolution (Issue #15)
+ * Unit tests for numbered prefix route resolution
  *
- * This test verifies that the plugin correctly uses Docusaurus resolved routes
- * before falling back to manual numbered prefix removal.
+ * Tests that the suffix-based matching correctly handles files and folders
+ * with numbered prefixes (e.g. "01-intro.md", "02-guide/").
  *
  * Run with: node tests/test-numbered-prefixes.js
  */
 
-const path = require('path');
-const fs = require('fs');
-
-/**
- * Test scenarios:
- * 1. Files with numbered prefixes: "01-intro.md"
- * 2. Nested numbered folders: "01-guide/01-start.md"
- * 3. Mixed numbered and non-numbered segments
- * 4. Exact match should be tried first before prefix removal
- */
-
 console.log('Running numbered prefix route resolution tests...\n');
 
-// Test 1: Exact match with numbered prefix in routeMap (should use exact match)
+// Re-implement the core helpers locally for isolated unit testing
+function findMatchingRoute(routesPaths, tail) {
+  const normalized = tail.toLowerCase().replace(/\/+$/, '');
+  if (!normalized) return undefined;
+  const matches = routesPaths.filter(route => {
+    const r = route.toLowerCase().replace(/\/+$/, '');
+    return r === `/${normalized}` || r.endsWith(`/${normalized}`);
+  });
+  if (matches.length <= 1) return matches[0];
+  return matches.sort((a, b) => a.length - b.length)[0];
+}
+
+function removeNumberedPrefixes(pathStr) {
+  return pathStr.split('/').map(segment => {
+    return segment.replace(/^\d+-/, '');
+  }).join('/');
+}
+
+function resolveWithCandidates(routesPaths, tail) {
+  const tails = new Set([tail]);
+  const stripped = removeNumberedPrefixes(tail);
+  if (stripped !== tail) tails.add(stripped);
+
+  for (const t of tails) {
+    const match = findMatchingRoute(routesPaths, t);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+// Test 1: Exact match with numbered prefix in routesPaths
 function testExactMatchWithNumberedPrefix() {
-  console.log('Test 1: Exact match with numbered prefix in routeMap');
+  console.log('Test 1: Exact match when route retains numbered prefix');
 
-  // Mock route map that contains the exact path with numbered prefix
-  const mockRouteMap = new Map([
-    ['/docs/01-intro', '/docs/introduction'],
-    ['/docs/guide/01-start', '/docs/guide/getting-started'],
-  ]);
+  const routesPaths = ['/docs/01-intro', '/docs/guide/01-start'];
 
-  // Simulate the logic from processor.ts (lines 289-354)
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first (without manual prefix removal)
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
+  const resolved1 = findMatchingRoute(routesPaths, '01-intro');
+  console.log(resolved1 === '/docs/01-intro'
+    ? '  ✅ PASS: Matched "01-intro" to "/docs/01-intro"'
+    : `  ❌ FAIL: Expected "/docs/01-intro", got "${resolved1}"`);
 
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 1a: File "01-intro.md"
-  const resolvedUrl1 = resolveRoute('docs/01-intro', 'docs', mockRouteMap);
-  const expected1 = '/docs/introduction';
-
-  if (resolvedUrl1 === expected1) {
-    console.log('  ✅ PASS: Correctly resolved "docs/01-intro" to "/docs/introduction"');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected1}", got "${resolvedUrl1}"`);
-  }
-
-  // Test case 1b: Nested file "guide/01-start.md"
-  const resolvedUrl2 = resolveRoute('docs/guide/01-start', 'docs', mockRouteMap);
-  const expected2 = '/docs/guide/getting-started';
-
-  if (resolvedUrl2 === expected2) {
-    console.log('  ✅ PASS: Correctly resolved "docs/guide/01-start" to "/docs/guide/getting-started"');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected2}", got "${resolvedUrl2}"`);
-  }
+  const resolved2 = findMatchingRoute(routesPaths, 'guide/01-start');
+  console.log(resolved2 === '/docs/guide/01-start'
+    ? '  ✅ PASS: Matched "guide/01-start" to "/docs/guide/01-start"'
+    : `  ❌ FAIL: Expected "/docs/guide/01-start", got "${resolved2}"`);
 
   console.log('');
 }
@@ -89,63 +62,17 @@ function testExactMatchWithNumberedPrefix() {
 function testFallbackToPrefixRemoval() {
   console.log('Test 2: Fallback to prefix removal when exact match not found');
 
-  // Mock route map that contains only the cleaned paths (no numbered prefixes)
-  const mockRouteMap = new Map([
-    ['/docs/intro', '/docs/introduction'],
-    ['/docs/guide/start', '/docs/guide/getting-started'],
-  ]);
+  const routesPaths = ['/docs/intro', '/docs/guide/start'];
 
-  // Simulate the logic from processor.ts
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
+  const resolved1 = resolveWithCandidates(routesPaths, '01-intro');
+  console.log(resolved1 === '/docs/intro'
+    ? '  ✅ PASS: "01-intro" fell back to "/docs/intro" via prefix removal'
+    : `  ❌ FAIL: Expected "/docs/intro", got "${resolved1}"`);
 
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 2a: File "01-intro.md" falls back to cleaning
-  const resolvedUrl1 = resolveRoute('docs/01-intro', 'docs', mockRouteMap);
-  const expected1 = '/docs/introduction';
-
-  if (resolvedUrl1 === expected1) {
-    console.log('  ✅ PASS: Correctly fell back to prefix removal for "docs/01-intro"');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected1}", got "${resolvedUrl1}"`);
-  }
-
-  // Test case 2b: Nested file "guide/01-start.md" falls back to cleaning
-  const resolvedUrl2 = resolveRoute('docs/guide/01-start', 'docs', mockRouteMap);
-  const expected2 = '/docs/guide/getting-started';
-
-  if (resolvedUrl2 === expected2) {
-    console.log('  ✅ PASS: Correctly fell back to prefix removal for "docs/guide/01-start"');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected2}", got "${resolvedUrl2}"`);
-  }
+  const resolved2 = resolveWithCandidates(routesPaths, '01-guide/01-start');
+  console.log(resolved2 === '/docs/guide/start'
+    ? '  ✅ PASS: "01-guide/01-start" fell back to "/docs/guide/start"'
+    : `  ❌ FAIL: Expected "/docs/guide/start", got "${resolved2}"`);
 
   console.log('');
 }
@@ -154,55 +81,13 @@ function testFallbackToPrefixRemoval() {
 function testExactMatchPrecedence() {
   console.log('Test 3: Exact match takes precedence over prefix removal');
 
-  // Mock route map that has BOTH the exact path and cleaned path
-  // This simulates a scenario where Docusaurus has resolved the route differently
-  const mockRouteMap = new Map([
-    ['/docs/01-intro', '/docs/numbered-intro'],  // Exact match
-    ['/docs/intro', '/docs/clean-intro'],         // Cleaned match
-  ]);
+  const routesPaths = ['/docs/01-intro', '/docs/intro'];
 
-  // Simulate the logic from processor.ts
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
-
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 3: File "01-intro.md" should use exact match, not cleaned
-  const resolvedUrl = resolveRoute('docs/01-intro', 'docs', mockRouteMap);
-  const expected = '/docs/numbered-intro';  // Should use exact match, not cleaned
-
-  if (resolvedUrl === expected) {
-    console.log(`  ✅ PASS: Correctly prioritized exact match "${expected}" over cleaned path`);
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected}", got "${resolvedUrl}"`);
-    console.log('  This indicates exact match is not being tried first!');
-  }
+  // The original tail "01-intro" matches first, before stripping
+  const resolved = resolveWithCandidates(routesPaths, '01-intro');
+  console.log(resolved === '/docs/01-intro'
+    ? '  ✅ PASS: Exact match "/docs/01-intro" preferred over stripped "/docs/intro"'
+    : `  ❌ FAIL: Expected "/docs/01-intro", got "${resolved}"`);
 
   console.log('');
 }
@@ -211,63 +96,20 @@ function testExactMatchPrecedence() {
 function testComplexNestedNumberedFolders() {
   console.log('Test 4: Complex nested numbered folders');
 
-  // Mock route map with multiple levels of numbered prefixes
-  const mockRouteMap = new Map([
-    ['/docs/01-guide/02-tutorials/03-advanced', '/docs/guide/tutorials/advanced'],
-    ['/docs/01-guide/02-tutorials', '/docs/guide/tutorials'],
-  ]);
+  const routesPaths = [
+    '/docs/guide/tutorials/advanced',
+    '/docs/guide/tutorials',
+  ];
 
-  // Simulate the logic from processor.ts
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
+  const resolved1 = resolveWithCandidates(routesPaths, '01-guide/02-tutorials/03-advanced');
+  console.log(resolved1 === '/docs/guide/tutorials/advanced'
+    ? '  ✅ PASS: Three-level nested numbered folders resolved'
+    : `  ❌ FAIL: Expected "/docs/guide/tutorials/advanced", got "${resolved1}"`);
 
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 4a: Three levels of numbered prefixes
-  const resolvedUrl1 = resolveRoute('docs/01-guide/02-tutorials/03-advanced', 'docs', mockRouteMap);
-  const expected1 = '/docs/guide/tutorials/advanced';
-
-  if (resolvedUrl1 === expected1) {
-    console.log('  ✅ PASS: Correctly resolved three-level nested numbered folders');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected1}", got "${resolvedUrl1}"`);
-  }
-
-  // Test case 4b: Two levels of numbered prefixes
-  const resolvedUrl2 = resolveRoute('docs/01-guide/02-tutorials', 'docs', mockRouteMap);
-  const expected2 = '/docs/guide/tutorials';
-
-  if (resolvedUrl2 === expected2) {
-    console.log('  ✅ PASS: Correctly resolved two-level nested numbered folders');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected2}", got "${resolvedUrl2}"`);
-  }
+  const resolved2 = resolveWithCandidates(routesPaths, '01-guide/02-tutorials');
+  console.log(resolved2 === '/docs/guide/tutorials'
+    ? '  ✅ PASS: Two-level nested numbered folders resolved'
+    : `  ❌ FAIL: Expected "/docs/guide/tutorials", got "${resolved2}"`);
 
   console.log('');
 }
@@ -276,63 +118,17 @@ function testComplexNestedNumberedFolders() {
 function testMixedNumberedSegments() {
   console.log('Test 5: Mixed numbered and non-numbered segments');
 
-  // Mock route map with mixed patterns
-  const mockRouteMap = new Map([
-    ['/docs/api/01-getting-started', '/docs/api/intro'],
-    ['/docs/01-guide/reference', '/docs/guide/ref'],
-  ]);
+  const routesPaths = ['/docs/api/getting-started', '/docs/guide/reference'];
 
-  // Simulate the logic from processor.ts
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
+  const resolved1 = resolveWithCandidates(routesPaths, 'api/01-getting-started');
+  console.log(resolved1 === '/docs/api/getting-started'
+    ? '  ✅ PASS: Non-numbered folder with numbered file resolved'
+    : `  ❌ FAIL: Expected "/docs/api/getting-started", got "${resolved1}"`);
 
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 5a: Non-numbered folder with numbered file
-  const resolvedUrl1 = resolveRoute('docs/api/01-getting-started', 'docs', mockRouteMap);
-  const expected1 = '/docs/api/intro';
-
-  if (resolvedUrl1 === expected1) {
-    console.log('  ✅ PASS: Correctly resolved non-numbered folder with numbered file');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected1}", got "${resolvedUrl1}"`);
-  }
-
-  // Test case 5b: Numbered folder with non-numbered file
-  const resolvedUrl2 = resolveRoute('docs/01-guide/reference', 'docs', mockRouteMap);
-  const expected2 = '/docs/guide/ref';
-
-  if (resolvedUrl2 === expected2) {
-    console.log('  ✅ PASS: Correctly resolved numbered folder with non-numbered file');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected2}", got "${resolvedUrl2}"`);
-  }
+  const resolved2 = resolveWithCandidates(routesPaths, '01-guide/reference');
+  console.log(resolved2 === '/docs/guide/reference'
+    ? '  ✅ PASS: Numbered folder with non-numbered file resolved'
+    : `  ❌ FAIL: Expected "/docs/guide/reference", got "${resolved2}"`);
 
   console.log('');
 }
@@ -341,71 +137,38 @@ function testMixedNumberedSegments() {
 function testTrailingSlashHandling() {
   console.log('Test 6: Trailing slash handling');
 
-  // Mock route map with trailing slashes
-  const mockRouteMap = new Map([
-    ['/docs/01-intro/', '/docs/introduction/'],
-    ['/docs/guide/', '/docs/guide-home/'],
-  ]);
+  const routesPaths = ['/docs/intro/', '/docs/guide/'];
 
-  // Simulate the logic from processor.ts
-  function resolveRoute(relativePath, pathPrefix, routeMap) {
-    // Try exact match first
-    const possiblePaths = [
-      `/${pathPrefix}/${relativePath}`,
-      `/${relativePath}`,
-    ];
+  const resolved1 = findMatchingRoute(routesPaths, 'intro');
+  console.log(resolved1 === '/docs/intro/'
+    ? '  ✅ PASS: Matched route with trailing slash'
+    : `  ❌ FAIL: Expected "/docs/intro/", got "${resolved1}"`);
 
-    for (const possiblePath of possiblePaths) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    // ONLY if exact match fails, try numbered prefix removal as fallback
-    const removeNumberedPrefixes = (path) => {
-      return path.split('/').map(segment => {
-        return segment.replace(/^\d+-/, '');
-      }).join('/');
-    };
-
-    const cleanPath = removeNumberedPrefixes(relativePath);
-
-    for (const possiblePath of [`/${pathPrefix}/${cleanPath}`, `/${cleanPath}`]) {
-      if (routeMap.has(possiblePath) || routeMap.has(possiblePath + '/')) {
-        return routeMap.get(possiblePath) || routeMap.get(possiblePath + '/');
-      }
-    }
-
-    return undefined;
-  }
-
-  // Test case 6a: Path without trailing slash, map has trailing slash
-  const resolvedUrl1 = resolveRoute('docs/01-intro', 'docs', mockRouteMap);
-  const expected1 = '/docs/introduction/';
-
-  if (resolvedUrl1 === expected1) {
-    console.log('  ✅ PASS: Correctly handled trailing slash in route map');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected1}", got "${resolvedUrl1}"`);
-  }
-
-  // Test case 6b: Non-numbered path with trailing slash
-  const resolvedUrl2 = resolveRoute('docs/guide', 'docs', mockRouteMap);
-  const expected2 = '/docs/guide-home/';
-
-  if (resolvedUrl2 === expected2) {
-    console.log('  ✅ PASS: Correctly handled trailing slash for non-numbered path');
-  } else {
-    console.log(`  ❌ FAIL: Expected "${expected2}", got "${resolvedUrl2}"`);
-  }
+  const resolved2 = findMatchingRoute(routesPaths, 'guide/');
+  console.log(resolved2 === '/docs/guide/'
+    ? '  ✅ PASS: Matched tail with trailing slash to route with trailing slash'
+    : `  ❌ FAIL: Expected "/docs/guide/", got "${resolved2}"`);
 
   console.log('');
 }
 
-// Run all tests
+// Test 7: Shortest match when multiple routes exist (versioned docs)
+function testShortestMatchPreference() {
+  console.log('Test 7: Shortest match preferred (stable over versioned)');
+
+  const routesPaths = ['/intro', '/nightly/intro', '/v2/intro'];
+
+  const resolved = findMatchingRoute(routesPaths, 'intro');
+  console.log(resolved === '/intro'
+    ? '  ✅ PASS: Shortest route "/intro" preferred over versioned'
+    : `  ❌ FAIL: Expected "/intro", got "${resolved}"`);
+
+  console.log('');
+}
+
 function runAllTests() {
   console.log('='.repeat(70));
-  console.log('Testing numbered prefix route resolution (Issue #15)');
+  console.log('Testing suffix-based numbered prefix route resolution');
   console.log('='.repeat(70));
   console.log('');
 
@@ -415,6 +178,7 @@ function runAllTests() {
   testComplexNestedNumberedFolders();
   testMixedNumberedSegments();
   testTrailingSlashHandling();
+  testShortestMatchPreference();
 
   console.log('='.repeat(70));
   console.log('All numbered prefix tests completed!');

--- a/tests/test-refactored-route-helpers.js
+++ b/tests/test-refactored-route-helpers.js
@@ -1,34 +1,28 @@
 /**
  * Unit tests for refactored route resolution helper functions
  *
- * Tests the extracted helper functions to ensure they work correctly in isolation
- * and maintain the same behavior as the original nested conditionals.
+ * Tests suffix-based matching logic and path normalization used by
+ * resolveDocumentUrl.
  */
 
 const path = require('path');
 
-// Test helper to normalize paths for cross-platform compatibility
 function normalizePath(filePath) {
   return filePath.split(path.sep).join('/');
 }
 
-// Import the processor module to access exported functions
-// Note: The helper functions are internal, so we test through the public API
 const { processFilesWithPatterns } = require('../lib/processor');
 
-// Mock context factory
 function createMockContext(options = {}) {
   return {
     siteDir: options.siteDir || '/test',
     siteUrl: options.siteUrl || 'https://example.com',
     docsDir: options.docsDir || 'docs',
     options: options.pluginOptions || {},
-    routeMap: options.routeMap || undefined,
     routesPaths: options.routesPaths || undefined,
   };
 }
 
-// Test suite
 async function runTests() {
   console.log('Running unit tests for refactored route resolution helpers...\n');
 
@@ -48,226 +42,193 @@ async function runTests() {
     }
   }
 
-  // Test 1: removeNumberedPrefixes function behavior
-  console.log('Test Group 1: Numbered prefix removal logic');
+  // Test 1: Suffix-based matching logic
+  console.log('Test Group 1: Suffix-based matching logic');
   {
-    // Test single segment
-    const input1 = '01-intro';
-    const expected1 = 'intro';
-    // We test this indirectly through the route resolution
-    assert(true, 'Single segment prefix removal', 'Tested through integration');
+    function findMatchingRoute(routesPaths, tail) {
+      const normalized = tail.toLowerCase().replace(/\/+$/, '');
+      if (!normalized) return undefined;
+      const matches = routesPaths.filter(route => {
+        const r = route.toLowerCase().replace(/\/+$/, '');
+        return r === `/${normalized}` || r.endsWith(`/${normalized}`);
+      });
+      if (matches.length <= 1) return matches[0];
+      return matches.sort((a, b) => a.length - b.length)[0];
+    }
 
-    // Test multiple segments
-    const input2 = '01-category/02-file';
-    const expected2 = 'category/file';
-    assert(true, 'Multiple segment prefix removal', 'Tested through integration');
+    assert(
+      findMatchingRoute(['/docs/simple'], 'simple') === '/docs/simple',
+      'Simple suffix match',
+      'Should match /docs/simple for tail "simple"'
+    );
 
-    // Test already clean path
-    const input3 = 'clean/path';
-    const expected3 = 'clean/path';
-    assert(true, 'Clean path unchanged', 'Tested through integration');
+    assert(
+      findMatchingRoute(['/simple', '/nightly/simple'], 'simple') === '/simple',
+      'Shortest match preferred',
+      'Should prefer /simple over /nightly/simple'
+    );
+
+    assert(
+      findMatchingRoute([], 'simple') === undefined,
+      'Empty routes returns undefined',
+      'Should return undefined for empty routes'
+    );
+
+    assert(
+      findMatchingRoute(['/docs/other'], 'simple') === undefined,
+      'No match returns undefined',
+      'Should return undefined when no route matches'
+    );
+
+    assert(
+      findMatchingRoute(['/docs/test'], '') === undefined,
+      'Empty tail returns undefined',
+      'Should return undefined for empty tail'
+    );
   }
 
-  // Test 2: findRouteInMap function behavior
-  console.log('\nTest Group 2: Route map lookup logic');
+  // Test 2: Directory collapsing logic
+  console.log('\nTest Group 2: Directory collapsing');
   {
-    const routeMap = new Map([
-      ['/docs/test', '/resolved-test'],
-      ['/docs/other/', '/resolved-other/'],
-    ]);
+    function collapseMatchingTrailingSegment(urlPath) {
+      const segments = urlPath.split('/');
+      if (segments.length >= 2) {
+        const last = segments[segments.length - 1];
+        const parent = segments[segments.length - 2];
+        if (last.toLowerCase() === parent.toLowerCase()) {
+          return segments.slice(0, -1).join('/');
+        }
+      }
+      return urlPath;
+    }
 
-    // Test exact match
-    const hasExact = routeMap.has('/docs/test');
-    assert(hasExact, 'Exact route map match', 'Should find exact key');
+    assert(
+      collapseMatchingTrailingSegment('generics/generics') === 'generics',
+      'Collapse matching trailing segment',
+      'Should collapse "generics/generics" to "generics"'
+    );
 
-    // Test trailing slash variant
-    const hasTrailing = routeMap.has('/docs/other/');
-    assert(hasTrailing, 'Trailing slash route match', 'Should find route with trailing slash');
+    assert(
+      collapseMatchingTrailingSegment('API/API') === 'API',
+      'Case-insensitive collapse',
+      'Should collapse case-insensitively'
+    );
 
-    // Test non-existent route
-    const hasNone = routeMap.has('/docs/nonexistent');
-    assert(!hasNone, 'Non-existent route returns false', 'Should not find missing route');
+    assert(
+      collapseMatchingTrailingSegment('intro/overview') === 'intro/overview',
+      'No collapse for non-matching',
+      'Should not collapse when segments differ'
+    );
+
+    assert(
+      collapseMatchingTrailingSegment('single') === 'single',
+      'Single segment unchanged',
+      'Should return single segment as-is'
+    );
   }
 
-  // Test 3: tryExactRouteMatch function behavior
-  console.log('\nTest Group 3: Exact route matching');
+  // Test 3: Numbered prefix removal
+  console.log('\nTest Group 3: Numbered prefix removal');
   {
-    const routeMap = new Map([
-      ['/docs/exact-match', '/resolved'],
-      ['/other-path', '/other-resolved'],
-    ]);
+    function removeNumberedPrefixes(pathStr) {
+      return pathStr.split('/').map(segment => {
+        return segment.replace(/^\d+-/, '');
+      }).join('/');
+    }
 
-    const context = createMockContext({ routeMap });
+    assert(
+      removeNumberedPrefixes('01-intro') === 'intro',
+      'Single segment prefix removal'
+    );
 
-    // Test with docs prefix
-    const hasDocsPrefix = routeMap.has('/docs/exact-match');
-    assert(hasDocsPrefix, 'Match with docs prefix', 'Should find /docs/exact-match');
+    assert(
+      removeNumberedPrefixes('01-category/02-file') === 'category/file',
+      'Multiple segment prefix removal'
+    );
 
-    // Test without prefix
-    const hasNoPrefix = routeMap.has('/other-path');
-    assert(hasNoPrefix, 'Match without prefix', 'Should find /other-path');
+    assert(
+      removeNumberedPrefixes('clean/path') === 'clean/path',
+      'Clean path unchanged'
+    );
 
-    // Test miss
-    const hasMiss = routeMap.has('/docs/missing');
-    assert(!hasMiss, 'No match for missing route', 'Should not find missing route');
+    assert(
+      removeNumberedPrefixes('01-a/no-prefix/03-c') === 'a/no-prefix/c',
+      'Mixed numbered and non-numbered segments'
+    );
   }
 
-  // Test 4: tryNumberedPrefixResolution function behavior
-  console.log('\nTest Group 4: Numbered prefix resolution');
+  // Test 4: Context without routesPaths
+  console.log('\nTest Group 4: Context without routesPaths');
   {
-    const routeMap = new Map([
-      ['/docs/intro', '/resolved-intro'],
-      ['/docs/category/file', '/resolved-file'],
-    ]);
+    const context = createMockContext({});
+    assert(!context.routesPaths, 'No routesPaths returns undefined', 'Should return undefined when no routesPaths');
 
-    const context = createMockContext({ routeMap });
-
-    // Test basic prefix removal
-    const hasBasic = routeMap.has('/docs/intro');
-    assert(hasBasic, 'Basic prefix match', 'Should match intro after removing 01-');
-
-    // Test nested prefix removal
-    const hasNested = routeMap.has('/docs/category/file');
-    assert(hasNested, 'Nested prefix match', 'Should match nested file');
+    const contextEmpty = createMockContext({ routesPaths: [] });
+    assert(contextEmpty.routesPaths.length === 0, 'Empty routesPaths handled', 'Should handle empty array');
   }
 
-  // Test 5: tryRoutesPathsMatch function behavior
-  console.log('\nTest Group 5: Routes paths array matching');
+  // Test 5: Suffix matching with trailing slashes
+  console.log('\nTest Group 5: Trailing slash handling in suffix matching');
   {
-    const routesPaths = [
-      '/docs/intro',
-      '/docs/category/nested',
-      '/docs/another',
-    ];
+    function findMatchingRoute(routesPaths, tail) {
+      const normalized = tail.toLowerCase().replace(/\/+$/, '');
+      if (!normalized) return undefined;
+      const matches = routesPaths.filter(route => {
+        const r = route.toLowerCase().replace(/\/+$/, '');
+        return r === `/${normalized}` || r.endsWith(`/${normalized}`);
+      });
+      if (matches.length <= 1) return matches[0];
+      return matches.sort((a, b) => a.length - b.length)[0];
+    }
 
-    const context = createMockContext({
-      routeMap: new Map(),
-      routesPaths
-    });
+    assert(
+      findMatchingRoute(['/docs/test/'], 'test') === '/docs/test/',
+      'Matches route with trailing slash',
+      'Should match routes that have trailing slashes'
+    );
 
-    // Test case-insensitive matching
-    const hasIntro = routesPaths.some(p => p.toLowerCase() === '/docs/intro');
-    assert(hasIntro, 'Case-insensitive match', 'Should find route case-insensitively');
-
-    // Test suffix matching
-    const hasNested = routesPaths.some(p => p.endsWith('/nested'));
-    assert(hasNested, 'Suffix match', 'Should find route by suffix');
-
-    // Test prefix matching
-    const hasPrefix = routesPaths.some(p => p === '/docs/another');
-    assert(hasPrefix, 'Full path match', 'Should find exact path match');
+    assert(
+      findMatchingRoute(['/docs/test'], 'test/') === '/docs/test',
+      'Matches tail with trailing slash',
+      'Should match when tail has trailing slash'
+    );
   }
 
-  // Test 6: resolveDocumentUrl early return behavior
-  console.log('\nTest Group 6: Early return when no route map');
+  // Test 6: Path normalization
+  console.log('\nTest Group 6: Path normalization');
   {
-    const context = createMockContext({
-      routeMap: undefined,
-    });
-
-    // When no route map, should return undefined (handled by processMarkdownFile fallback)
-    assert(!context.routeMap, 'No route map returns undefined', 'Should return undefined when no route map');
-  }
-
-  // Test 7: Integration test - full resolution flow
-  console.log('\nTest Group 7: Full resolution flow');
-  {
-    const routeMap = new Map([
-      ['/docs/simple', '/resolved-simple'],
-      ['/docs/numbered', '/resolved-numbered'],
-      ['/docs/category/nested', '/resolved-nested'],
-    ]);
-
-    const routesPaths = [
-      '/docs/fallback',
-    ];
-
-    const context = createMockContext({
-      routeMap,
-      routesPaths
-    });
-
-    // Test exact match priority
-    const hasExact = routeMap.has('/docs/simple');
-    assert(hasExact, 'Exact match takes priority', 'Should find exact match first');
-
-    // Test numbered prefix fallback
-    const hasNumbered = routeMap.has('/docs/numbered');
-    assert(hasNumbered, 'Numbered prefix fallback', 'Should fall back to prefix removal');
-
-    // Test routes paths fallback
-    const hasFallback = routesPaths.includes('/docs/fallback');
-    assert(hasFallback, 'Routes paths fallback', 'Should fall back to routes paths array');
-  }
-
-  // Test 8: Edge cases
-  console.log('\nTest Group 8: Edge cases');
-  {
-    // Empty route map
-    const emptyMap = new Map();
-    const context1 = createMockContext({ routeMap: emptyMap });
-    assert(context1.routeMap.size === 0, 'Empty route map', 'Should handle empty map');
-
-    // Multiple numbered segments
-    const routeMap2 = new Map([
-      ['/docs/section/item', '/resolved'],
-    ]);
-    const context2 = createMockContext({ routeMap: routeMap2 });
-    assert(context2.routeMap.size === 1, 'Multiple numbered segments', 'Should handle multiple segments');
-
-    // Trailing slash variations
-    const routeMap3 = new Map([
-      ['/docs/test', '/resolved'],
-      ['/docs/test/', '/resolved/'],
-    ]);
-    const hasWithout = routeMap3.has('/docs/test');
-    const hasWith = routeMap3.has('/docs/test/');
-    assert(hasWithout && hasWith, 'Trailing slash variations', 'Should handle both with and without trailing slash');
-  }
-
-  // Test 9: Path normalization
-  console.log('\nTest Group 9: Path normalization');
-  {
-    // Test Windows-style paths converted to URL paths
-    // On non-Windows systems, path.sep is '/', so we manually test the conversion logic
     const windowsPath = 'docs\\subfolder\\file.md';
     const normalized = windowsPath.split('\\').join('/');
-    assert(normalized === 'docs/subfolder/file.md', 'Windows path normalization', 'Should convert backslashes to forward slashes');
+    assert(normalized === 'docs/subfolder/file.md', 'Windows path normalization');
 
-    // Test index file handling
     const indexPath = 'docs/intro/index.md';
-    const expectedBase = 'docs/intro';
     const withoutExt = indexPath.replace(/\.mdx?$/, '');
     const withoutIndex = withoutExt.replace(/\/index$/, '');
-    assert(withoutIndex === expectedBase, 'Index file handling', 'Should remove /index from path');
+    assert(withoutIndex === 'docs/intro', 'Index file handling');
 
-    // Test file extension removal
     const mdPath = 'docs/file.md';
     const mdxPath = 'docs/file.mdx';
-    const withoutMd = mdPath.replace(/\.mdx?$/, '');
-    const withoutMdx = mdxPath.replace(/\.mdx?$/, '');
-    assert(withoutMd === 'docs/file' && withoutMdx === 'docs/file', 'Extension removal', 'Should remove .md and .mdx extensions');
+    assert(mdPath.replace(/\.mdx?$/, '') === 'docs/file', '.md extension removal');
+    assert(mdxPath.replace(/\.mdx?$/, '') === 'docs/file', '.mdx extension removal');
   }
 
-  // Test 10: URL construction with base URL
-  console.log('\nTest Group 10: URL construction');
+  // Test 7: URL construction
+  console.log('\nTest Group 7: URL construction');
   {
     const siteUrl = 'https://example.com';
     const resolvedPath = '/docs/test';
 
-    // Test URL construction
     try {
       const fullUrl = new URL(resolvedPath, siteUrl).toString();
-      assert(fullUrl === 'https://example.com/docs/test', 'URL construction', 'Should construct valid URL');
+      assert(fullUrl === 'https://example.com/docs/test', 'URL construction');
     } catch (e) {
       assert(false, 'URL construction', 'Should not throw error');
     }
 
-    // Test with trailing slash in site URL
     const siteUrlWithSlash = 'https://example.com/';
     try {
       const fullUrl2 = new URL(resolvedPath, siteUrlWithSlash).toString();
-      assert(fullUrl2 === 'https://example.com/docs/test', 'URL construction with trailing slash', 'Should handle trailing slash');
+      assert(fullUrl2 === 'https://example.com/docs/test', 'URL construction with trailing slash');
     } catch (e) {
       assert(false, 'URL construction with trailing slash', 'Should not throw error');
     }
@@ -283,7 +244,6 @@ async function runTests() {
   }
 }
 
-// Run the tests
 runTests().catch(err => {
   console.error('Unexpected error:', err);
   process.exit(1);

--- a/tests/test-route-resolution-helpers.js
+++ b/tests/test-route-resolution-helpers.js
@@ -1,22 +1,19 @@
 /**
  * Test route resolution helper functions
  *
- * Tests the extracted helper functions for URL resolution from route maps.
- * These tests verify that the refactored code maintains the same behavior.
+ * Tests suffix-based URL resolution using routesPaths.
  */
 
 const path = require('path');
 const fs = require('fs-extra');
 const { processFilesWithPatterns } = require('../lib/processor');
 
-// Test data setup
 const TEST_DIR = path.join(__dirname, 'route-helpers-test');
 const DOCS_DIR = path.join(TEST_DIR, 'docs');
 
 async function setupTestFiles() {
   await fs.ensureDir(DOCS_DIR);
 
-  // Create test files with different naming patterns
   await fs.writeFile(
     path.join(DOCS_DIR, 'simple.md'),
     '# Simple\n\nSimple test file.'
@@ -32,7 +29,6 @@ async function setupTestFiles() {
     '# Another\n\nAnother numbered file.'
   );
 
-  // Nested folder with numbered prefix
   await fs.ensureDir(path.join(DOCS_DIR, '01-category'));
   await fs.writeFile(
     path.join(DOCS_DIR, '01-category', 'nested.md'),
@@ -55,20 +51,15 @@ async function runTests() {
   try {
     await setupTestFiles();
 
-    // Test 1: Exact route match
-    console.log('Test 1: Exact route match');
+    // Test 1: Suffix-based matching via routesPaths
+    console.log('Test 1: Suffix-based route matching');
     {
-      const routeMap = new Map([
-        ['/docs/simple', '/simple'],
-        ['/docs/01-numbered', '/numbered'],
-      ]);
-
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        routeMap,
+        routesPaths: ['/simple', '/numbered'],
       };
 
       const allFiles = [
@@ -78,79 +69,70 @@ async function runTests() {
 
       const results = await processFilesWithPatterns(context, allFiles);
 
-      // Verify that exact matches are found
       const simpleDoc = results.find(doc => doc.path === 'docs/simple.md');
       const numberedDoc = results.find(doc => doc.path === 'docs/01-numbered.md');
 
       if (simpleDoc && simpleDoc.url === 'https://example.com/simple') {
-        console.log('  ✓ PASS: Exact match for simple.md');
+        console.log('  ✓ PASS: Suffix match for simple.md');
       } else {
         console.log('  ✗ FAIL: Expected simple.md to resolve to /simple');
         console.log(`    Got: ${simpleDoc?.url}`);
       }
 
       if (numberedDoc && numberedDoc.url === 'https://example.com/numbered') {
-        console.log('  ✓ PASS: Exact match for numbered file');
+        console.log('  ✓ PASS: Suffix match for numbered file (prefix stripped)');
       } else {
         console.log('  ✗ FAIL: Expected 01-numbered.md to resolve to /numbered');
         console.log(`    Got: ${numberedDoc?.url}`);
       }
     }
 
-    // Test 2: Cleaned path match (numbered prefix removal)
-    console.log('\nTest 2: Cleaned path match (numbered prefix removal)');
+    // Test 2: Numbered prefix removal via routesPaths
+    console.log('\nTest 2: Numbered prefix removal');
     {
-      const routeMap = new Map([
-        ['/docs/another', '/another'],  // No numbered prefix in route
-      ]);
-
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        routeMap,
+        routesPaths: ['/another'],
       };
 
       const allFiles = [
-        path.join(DOCS_DIR, '02-another.md'),  // Has numbered prefix in filename
+        path.join(DOCS_DIR, '02-another.md'),
       ];
 
       const results = await processFilesWithPatterns(context, allFiles);
       const doc = results[0];
 
       if (doc && doc.url === 'https://example.com/another') {
-        console.log('  ✓ PASS: Cleaned path match removes numbered prefix');
+        console.log('  ✓ PASS: Numbered prefix stripped and matched');
       } else {
         console.log('  ✗ FAIL: Expected 02-another.md to resolve to /another');
         console.log(`    Got: ${doc?.url}`);
       }
     }
 
-    // Test 3: Segment-wise match (nested folders with numbered prefixes)
-    console.log('\nTest 3: Segment-wise match (nested folders)');
+    // Test 3: Nested folders with numbered prefixes
+    console.log('\nTest 3: Nested folders with numbered prefixes');
     {
-      const routeMap = new Map([
-        ['/docs/category/nested', '/category/nested'],  // Category without number
-      ]);
-
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        routeMap,
+        routesPaths: ['/category/nested'],
       };
 
       const allFiles = [
-        path.join(DOCS_DIR, '01-category', 'nested.md'),  // Folder has numbered prefix
+        path.join(DOCS_DIR, '01-category', 'nested.md'),
       ];
 
       const results = await processFilesWithPatterns(context, allFiles);
       const doc = results[0];
 
       if (doc && doc.url === 'https://example.com/category/nested') {
-        console.log('  ✓ PASS: Segment-wise match removes folder prefix');
+        console.log('  ✓ PASS: Nested numbered prefix stripped and matched');
       } else {
         console.log('  ✗ FAIL: Expected nested file to resolve to /category/nested');
         console.log(`    Got: ${doc?.url}`);
@@ -160,16 +142,12 @@ async function runTests() {
     // Test 4: Double numbered prefixes
     console.log('\nTest 4: Double numbered prefixes');
     {
-      const routeMap = new Map([
-        ['/docs/category/double', '/category/double'],
-      ]);
-
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        routeMap,
+        routesPaths: ['/category/double'],
       };
 
       const allFiles = [
@@ -187,15 +165,14 @@ async function runTests() {
       }
     }
 
-    // Test 5: Fallback when no route map exists
-    console.log('\nTest 5: Fallback when no route map exists');
+    // Test 5: Fallback when no routesPaths exist
+    console.log('\nTest 5: Fallback when no routesPaths exist');
     {
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        // No routeMap provided
       };
 
       const allFiles = [
@@ -205,7 +182,6 @@ async function runTests() {
       const results = await processFilesWithPatterns(context, allFiles);
       const doc = results[0];
 
-      // Should fall back to path-based URL construction
       if (doc && doc.url === 'https://example.com/docs/simple') {
         console.log('  ✓ PASS: Fallback URL construction works');
       } else {
@@ -214,23 +190,15 @@ async function runTests() {
       }
     }
 
-    // Test 6: Best route match with routesPaths
-    console.log('\nTest 6: Best route match with routesPaths');
+    // Test 6: Versioned routes — shortest match preferred
+    console.log('\nTest 6: Shortest route match preferred (stable over versioned)');
     {
-      const routeMap = new Map();  // Empty route map
-      const routesPaths = [
-        '/docs/another',
-        '/docs/category/nested',
-        '/docs/simple',
-      ];
-
       const context = {
         siteDir: TEST_DIR,
         siteUrl: 'https://example.com',
         docsDir: 'docs',
         options: {},
-        routeMap,
-        routesPaths,
+        routesPaths: ['/another', '/nightly/another'],
       };
 
       const allFiles = [
@@ -240,11 +208,10 @@ async function runTests() {
       const results = await processFilesWithPatterns(context, allFiles);
       const doc = results[0];
 
-      // Should find best match from routesPaths
-      if (doc && doc.url === 'https://example.com/docs/another') {
-        console.log('  ✓ PASS: Best route match from routesPaths works');
+      if (doc && doc.url === 'https://example.com/another') {
+        console.log('  ✓ PASS: Shortest route (stable) preferred over versioned');
       } else {
-        console.log('  ✗ FAIL: Expected best match to find /docs/another');
+        console.log('  ✗ FAIL: Expected shortest match /another');
         console.log(`    Got: ${doc?.url}`);
       }
     }

--- a/tests/test-route-resolution-helpers.js
+++ b/tests/test-route-resolution-helpers.js
@@ -216,6 +216,162 @@ async function runTests() {
       }
     }
 
+    // Test 7: Issue #31 — docsDir stripping prevents doubled paths
+    // When routeBasePath is '/', Docusaurus routes are /manual/get-started
+    // (not /docs/manual/get-started). Without docsDir stripping the tail
+    // would be "docs/manual/get-started" and fall through to the fallback,
+    // producing the doubled /docs/docs/manual/get-started URL.
+    console.log('\nTest 7: Issue #31 — docsDir stripping prevents docs/docs doubling');
+    {
+      await fs.ensureDir(path.join(DOCS_DIR, 'manual'));
+      await fs.writeFile(
+        path.join(DOCS_DIR, 'manual', 'get-started.md'),
+        '# Get Started\n\nGet started guide.'
+      );
+
+      const context = {
+        siteDir: TEST_DIR,
+        siteUrl: 'https://example.com',
+        docsDir: 'docs',
+        options: {},
+        routesPaths: ['/manual/get-started'],
+      };
+
+      const allFiles = [
+        path.join(DOCS_DIR, 'manual', 'get-started.md'),
+      ];
+
+      const results = await processFilesWithPatterns(context, allFiles);
+      const doc = results[0];
+
+      if (doc && doc.url === 'https://example.com/manual/get-started') {
+        console.log('  ✓ PASS: No docs/docs doubling — resolved to /manual/get-started');
+      } else {
+        console.log('  ✗ FAIL: Expected /manual/get-started (not /docs/docs/manual/get-started)');
+        console.log(`    Got: ${doc?.url}`);
+      }
+    }
+
+    // Test 8: Issue #30 — trailing-slash routes resolve correctly
+    console.log('\nTest 8: Issue #30 — trailing-slash routes produce correct URLs');
+    {
+      const context = {
+        siteDir: TEST_DIR,
+        siteUrl: 'https://example.com',
+        docsDir: 'docs',
+        options: {},
+        routesPaths: ['/simple/'],
+      };
+
+      const allFiles = [
+        path.join(DOCS_DIR, 'simple.md'),
+      ];
+
+      const results = await processFilesWithPatterns(context, allFiles);
+      const doc = results[0];
+
+      if (doc && doc.url === 'https://example.com/simple/') {
+        console.log('  ✓ PASS: Trailing-slash route matched and URL preserved');
+      } else {
+        console.log('  ✗ FAIL: Expected URL with trailing slash /simple/');
+        console.log(`    Got: ${doc?.url}`);
+      }
+    }
+
+    // Test 9: Directory collapsing (generics/generics.md -> /generics)
+    console.log('\nTest 9: Directory collapsing — dir/dir.md resolves to /dir');
+    {
+      await fs.ensureDir(path.join(DOCS_DIR, 'generics'));
+      await fs.writeFile(
+        path.join(DOCS_DIR, 'generics', 'generics.md'),
+        '# Generics\n\nGenerics documentation.'
+      );
+
+      const context = {
+        siteDir: TEST_DIR,
+        siteUrl: 'https://example.com',
+        docsDir: 'docs',
+        options: {},
+        routesPaths: ['/generics'],
+      };
+
+      const allFiles = [
+        path.join(DOCS_DIR, 'generics', 'generics.md'),
+      ];
+
+      const results = await processFilesWithPatterns(context, allFiles);
+      const doc = results[0];
+
+      if (doc && doc.url === 'https://example.com/generics') {
+        console.log('  ✓ PASS: generics/generics.md collapsed to /generics');
+      } else {
+        console.log('  ✗ FAIL: Expected /generics (not /generics/generics)');
+        console.log(`    Got: ${doc?.url}`);
+      }
+    }
+
+    // Test 10: Frontmatter id override — filename differs from route
+    console.log('\nTest 10: Frontmatter id override resolves correct route');
+    {
+      await fs.writeFile(
+        path.join(DOCS_DIR, 'python_to_mojo.md'),
+        '---\nid: python-to-mojo\n---\n# Python to Mojo\n\nMigration guide.'
+      );
+
+      const context = {
+        siteDir: TEST_DIR,
+        siteUrl: 'https://example.com',
+        docsDir: 'docs',
+        options: {},
+        routesPaths: ['/python-to-mojo'],
+      };
+
+      const allFiles = [
+        path.join(DOCS_DIR, 'python_to_mojo.md'),
+      ];
+
+      const results = await processFilesWithPatterns(context, allFiles);
+      const doc = results[0];
+
+      if (doc && doc.url === 'https://example.com/python-to-mojo') {
+        console.log('  ✓ PASS: Frontmatter id override resolved to /python-to-mojo');
+      } else {
+        console.log('  ✗ FAIL: Expected /python-to-mojo via frontmatter id override');
+        console.log(`    Got: ${doc?.url}`);
+      }
+    }
+
+    // Test 11: Frontmatter slug override
+    console.log('\nTest 11: Frontmatter slug override resolves correct route');
+    {
+      await fs.writeFile(
+        path.join(DOCS_DIR, 'intro.md'),
+        '---\nslug: /welcome\n---\n# Welcome\n\nWelcome page.'
+      );
+
+      const context = {
+        siteDir: TEST_DIR,
+        siteUrl: 'https://example.com',
+        docsDir: 'docs',
+        options: {},
+        routesPaths: ['/welcome'],
+      };
+
+      const allFiles = [
+        path.join(DOCS_DIR, 'intro.md'),
+      ];
+
+      const results = await processFilesWithPatterns(context, allFiles);
+      const doc = results[0];
+
+      if (doc && doc.url === 'https://example.com/welcome') {
+        console.log('  ✓ PASS: Frontmatter slug override resolved to /welcome');
+      } else {
+        console.log('  ✗ FAIL: Expected /welcome via frontmatter slug override');
+        console.log(`    Got: ${doc?.url}`);
+      }
+    }
+
     console.log('\n✓ All route resolution helper tests completed');
 
   } catch (err) {


### PR DESCRIPTION
Replaces the route-map lookup approach with suffix-based matching against
Docusaurus's `routesPaths`, fixing incorrect URL generation in some
common configurations.

The refactor removes ~150 lines of production code, eliminating `routeMap`,
its recursive construction in `postBuild`, and five cascading helper
functions that each handled a different edge case. These are replaced by a
single `findMatchingRoute` function that suffix-matches against Docusaurus's
own route table, making the resolution both simpler and more correct.

### Fixes

- **#31** — Doubled `docs/docs/` paths when `routeBasePath: '/'` and docs live in a nested `docs/` subdirectory
- **#30** — `trailingSlash: true` not reflected in generated URLs

### How it works

Instead of constructing route-map keys from file paths (which required
knowledge of `routeBasePath`, version prefixes, and other routing details),
the plugin now strips `docsDir` and the file extension to get a "tail," then
finds any route ending with that tail. This naturally handles directory
collapsing, numbered prefixes, versioned routes, and frontmatter `id`/`slug`
overrides.

### Other changes

- Removed `routeMap`, its construction in `postBuild`, and five helper functions, replaced by a single `findMatchingRoute` function
- Updated existing tests and added regression tests for #30 and #31
- Updated README and TESTING.md to document the new behavior
- `pathTransformation` is now only applied as a fallback

Made-with: Cursor