### PR TITLE
docs: clarify plugin runs on build only, not dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,8 @@ Generate both original links and markdown files for different use cases:
 
 ## How It Works
 
+> **Note:** This plugin uses the `postBuild` lifecycle hook and only runs during `npm run build`. It does not run during `docusaurus start` (the development server).
+
 This plugin automatically generates the following files during the build process:
 
 - **llms.txt**: Contains links to all sections of your documentation


### PR DESCRIPTION
Fixes #26

Adds a note to the README clarifying that the plugin uses the postBuild hook and only runs during `npm run build`, not `docusaurus start`.