### PR TITLE
feat: support multiple docs sections via docsDir array

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cleanup": "node cleanup.js",
     "prepublishOnly": "npm run build && npm run cleanup",
     "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js",
-    "test:integration": "node tests/test-path-transformation.js",
+    "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js",
     "test": "npm run build && npm run test:unit && npm run test:integration"
   },
   "files": [

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -149,20 +149,47 @@ ${doc.content}`;
     }
   } else {
     // Generate links-only file
-    const tocItems = docs.map(doc => {
-      // Clean and format the description for TOC
-      const cleanedDescription = cleanDescriptionForToc(doc.description);
-      
-      return `- [${doc.title}](${doc.url})${cleanedDescription ? `: ${cleanedDescription}` : ''}`;
-    });
+    const docsHaveSections = docs.some(doc => doc.section);
+
+    let tocContent: string;
+
+    if (docsHaveSections) {
+      // Group docs by section and emit ## Section headings
+      const sectionMap = new Map<string, string[]>();
+      for (const doc of docs) {
+        const sectionKey = doc.section || '';
+        if (!sectionMap.has(sectionKey)) {
+          sectionMap.set(sectionKey, []);
+        }
+        const cleanedDescription = cleanDescriptionForToc(doc.description);
+        sectionMap.get(sectionKey)!.push(
+          `- [${doc.title}](${doc.url})${cleanedDescription ? `: ${cleanedDescription}` : ''}`
+        );
+      }
+
+      const sectionBlocks: string[] = [];
+      for (const [sectionLabel, items] of sectionMap) {
+        const heading = isNonEmptyString(sectionLabel) ? `## ${sectionLabel}\n\n` : '';
+        sectionBlocks.push(`${heading}${items.join('\n')}`);
+      }
+
+      tocContent = sectionBlocks.join('\n\n');
+    } else {
+      const tocItems = docs.map(doc => {
+        // Clean and format the description for TOC
+        const cleanedDescription = cleanDescriptionForToc(doc.description);
+        return `- [${doc.title}](${doc.url})${cleanedDescription ? `: ${cleanedDescription}` : ''}`;
+      });
+      tocContent = `## Table of Contents\n\n${tocItems.join('\n')}`;
+    }
 
     // Use custom root content or default message
     const rootContent = customRootContent || 'This file contains links to documentation sections following the llmstxt.org standard.';
-    
+
     const llmFileContent = createMarkdownContent(
       fileTitle,
       `${fileDescription}${versionInfo}`,
-      `${rootContent}\n\n## Table of Contents\n\n${tocItems.join('\n')}`,
+      `${rootContent}\n\n${tocContent}`,
       true // include metadata (description)
     );
 
@@ -524,40 +551,42 @@ export async function generateCustomLLMFiles(
  * @returns Array of file paths
  */
 export async function collectDocFiles(context: PluginContext): Promise<string[]> {
-  const { siteDir, docsDir, options } = context;
+  const { siteDir, options, docsSections } = context;
   const { ignoreFiles = [], includeBlog = false, warnOnIgnoredFiles = false } = options;
-  
+
   const allDocFiles: string[] = [];
-  
-  // Process docs directory
-  const fullDocsDir = path.join(siteDir, docsDir);
-  
-  try {
-    await fs.access(fullDocsDir);
 
-    // Collect all markdown files from docs directory
-    const docFiles = await readMarkdownFiles(fullDocsDir, siteDir, ignoreFiles, docsDir, warnOnIgnoredFiles);
-    allDocFiles.push(...docFiles);
+  // Process each docs section
+  for (const section of docsSections) {
+    const fullDocsDir = path.join(siteDir, section.path);
 
-  } catch (err: unknown) {
-    logger.warn(`Docs directory not found: ${fullDocsDir}`);
+    try {
+      await fs.access(fullDocsDir);
+
+      // Collect all markdown files from this section's directory
+      const docFiles = await readMarkdownFiles(fullDocsDir, siteDir, ignoreFiles, section.path, warnOnIgnoredFiles);
+      allDocFiles.push(...docFiles);
+
+    } catch (err: unknown) {
+      logger.warn(`Docs directory not found: ${fullDocsDir}`);
+    }
   }
-  
+
   // Process blog if enabled
   if (includeBlog) {
     const blogDir = path.join(siteDir, 'blog');
-    
+
     try {
       await fs.access(blogDir);
 
       // Collect all markdown files from blog directory
-      const blogFiles = await readMarkdownFiles(blogDir, siteDir, ignoreFiles, docsDir, warnOnIgnoredFiles);
+      const blogFiles = await readMarkdownFiles(blogDir, siteDir, ignoreFiles, context.docsDir, warnOnIgnoredFiles);
       allDocFiles.push(...blogFiles);
 
     } catch (err: unknown) {
       logger.warn(`Blog directory not found: ${blogDir}`);
     }
   }
-  
+
   return allDocFiles;
 } 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
 
 import * as path from 'path';
 import type { LoadContext, Plugin, Props } from '@docusaurus/types';
-import { PluginOptions, PluginContext, CustomLLMFile } from './types';
+import { PluginOptions, PluginContext, CustomLLMFile, DocsSection } from './types';
 import { collectDocFiles, generateStandardLLMFiles, generateCustomLLMFiles } from './generator';
 import { setLogLevel, LogLevel, logger, getErrorMessage, isDefined, isNonEmptyString, isNonEmptyArray } from './utils';
 
@@ -85,9 +85,31 @@ function validatePluginOptions(options: PluginOptions): void {
     }
   }
 
+  // Validate docsDir (string or array of section objects)
+  if (options.docsDir !== undefined) {
+    if (typeof options.docsDir !== 'string' && !Array.isArray(options.docsDir)) {
+      throw new Error('docsDir must be a string or an array of section objects');
+    }
+    if (Array.isArray(options.docsDir)) {
+      (options.docsDir as DocsSection[]).forEach((section, index) => {
+        if (typeof section !== 'object' || section === null) {
+          throw new Error(`docsDir[${index}] must be an object`);
+        }
+        if (typeof section.path !== 'string' || section.path.trim() === '') {
+          throw new Error(`docsDir[${index}].path must be a non-empty string`);
+        }
+        if (typeof section.routeBasePath !== 'string' || section.routeBasePath.trim() === '') {
+          throw new Error(`docsDir[${index}].routeBasePath must be a non-empty string`);
+        }
+        if (section.label !== undefined && (typeof section.label !== 'string' || section.label.trim() === '')) {
+          throw new Error(`docsDir[${index}].label must be a non-empty string`);
+        }
+      });
+    }
+  }
+
   // Validate string options
   const stringOptions = [
-    'docsDir',
     'title',
     'description',
     'llmsTxtFilename',
@@ -208,7 +230,7 @@ export default function docusaurusPluginLLMs(
   const {
     generateLLMsTxt = true,
     generateLLMsFullTxt = true,
-    docsDir = 'docs',
+    docsDir,
     ignoreFiles = [],
     title,
     description,
@@ -230,6 +252,18 @@ export default function docusaurusPluginLLMs(
     processingBatchSize = 100,
     warnOnIgnoredFiles = false,
   } = options;
+
+  // Normalize docsDir into docsSections array
+  const docsSections: DocsSection[] =
+    Array.isArray(docsDir) && docsDir.length > 0
+      ? (docsDir as DocsSection[])
+      : [{
+          path: typeof docsDir === 'string' ? docsDir : 'docs',
+          routeBasePath: typeof docsDir === 'string' ? docsDir : 'docs',
+        }];
+
+  // Resolved string form of docsDir for backward-compat fields
+  const resolvedDocsDir = docsSections[0].path;
 
   // Initialize logging level
   const logLevelMap = {
@@ -257,9 +291,10 @@ export default function docusaurusPluginLLMs(
     siteDir,
     outDir,
     siteUrl,
-    docsDir,
+    docsDir: resolvedDocsDir,
     docTitle: title || siteConfig.title,
     docDescription: description || siteConfig.tagline || '',
+    docsSections,
     options: {
       generateLLMsTxt,
       generateLLMsFullTxt,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -450,7 +450,30 @@ export async function processFilesWithPatterns(
       try {
         const baseDir = siteDir;
         const isBlogFile = filePath.includes(path.join(siteDir, 'blog'));
-        const pathPrefix = isBlogFile ? 'blog' : 'docs';
+
+        // Determine which section this file belongs to
+        let pathPrefix: string;
+        let sectionLabel: string | undefined;
+
+        if (isBlogFile) {
+          pathPrefix = 'blog';
+        } else if (context.docsSections && context.docsSections.length > 0) {
+          const matchedSection = context.docsSections.find(s => {
+            const sectionDir = path.join(siteDir, s.path);
+            return filePath.startsWith(sectionDir + path.sep) || filePath.startsWith(sectionDir + '/');
+          });
+
+          if (matchedSection) {
+            pathPrefix = matchedSection.routeBasePath;
+            if (context.docsSections.length > 1) {
+              sectionLabel = matchedSection.label || matchedSection.path;
+            }
+          } else {
+            pathPrefix = docsDir;
+          }
+        } else {
+          pathPrefix = docsDir;
+        }
 
         const resolvedUrl = await resolveDocumentUrl(filePath, baseDir, context);
 
@@ -468,6 +491,11 @@ export async function processFilesWithPatterns(
           context.options.removeDuplicateHeadings || false,
           resolvedUrl
         );
+
+        if (docInfo && sectionLabel) {
+          docInfo.section = sectionLabel;
+        }
+
         return docInfo;
       } catch (err: unknown) {
         logger.warn(`Error processing ${filePath}: ${getErrorMessage(err)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,18 @@
  */
 
 /**
+ * Interface for a documentation section (used when docsDir is an array)
+ */
+export interface DocsSection {
+  /** Filesystem path relative to siteDir (e.g., 'docs', 'api') */
+  path: string;
+  /** Docusaurus routeBasePath for this section (e.g., 'docs', 'api') */
+  routeBasePath: string;
+  /** Optional human-readable label shown as a section heading in llms.txt */
+  label?: string;
+}
+
+/**
  * Interface for processed document information
  */
 export interface DocInfo {
@@ -12,6 +24,8 @@ export interface DocInfo {
   content: string;
   description: string;
   frontMatter?: Record<string, any>;
+  /** Section label assigned when multiple docsDir sections are configured */
+  section?: string;
 }
 
 /**
@@ -59,8 +73,8 @@ export interface PluginOptions {
   /** Whether to generate the llms-full.txt file (default: true) */
   generateLLMsFullTxt?: boolean;
   
-  /** Base directory for documentation files (default: 'docs') */
-  docsDir?: string;
+  /** Base directory for documentation files (default: 'docs'), or an array of section objects */
+  docsDir?: string | DocsSection[];
   
   /** Array of glob patterns for files to ignore */
   ignoreFiles?: string[];
@@ -146,4 +160,5 @@ export interface PluginContext {
   docDescription: string;
   options: PluginOptions;
   routesPaths?: string[];
+  docsSections: DocsSection[];
 } 

--- a/tests/test-multi-doc.js
+++ b/tests/test-multi-doc.js
@@ -1,0 +1,278 @@
+/**
+ * Integration tests for multi-docs support (docsDir as array of section objects)
+ *
+ * Run with: node tests/test-multi-doc.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const pluginModule = require('../lib/index');
+const plugin = pluginModule.default;
+
+console.log('Testing multi-docs support...\n');
+
+let passedTests = 0;
+let failedTests = 0;
+
+function pass(name) {
+  console.log(`  PASS: ${name}`);
+  passedTests++;
+}
+
+function fail(name, reason) {
+  console.log(`  FAIL: ${name}`);
+  console.log(`     ${reason}`);
+  failedTests++;
+}
+
+/**
+ * Create a temp directory with docs/ and api/ subdirectories containing test fixtures
+ */
+function createTempSite() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-llms-test-'));
+  const outDir = path.join(tmpDir, 'out');
+
+  fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'api'), { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tmpDir, 'docs', 'getting-started.md'),
+    '---\ntitle: Getting Started\ndescription: Start here.\n---\n\n# Getting Started\n\nStart here.'
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, 'api', 'authentication.md'),
+    '---\ntitle: Authentication\ndescription: API auth docs.\n---\n\n# Authentication\n\nAPI auth docs.'
+  );
+
+  return { tmpDir, outDir };
+}
+
+function cleanup(tmpDir) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+function makeMockContext(tmpDir, outDir) {
+  return {
+    siteDir: tmpDir,
+    siteConfig: {
+      title: 'Test Site',
+      tagline: 'Testing multi-docs',
+      url: 'https://example.com',
+      baseUrl: '/',
+    },
+    outDir,
+  };
+}
+
+// Test 1: Two labeled sections produce grouped ## Section headings in llms.txt
+async function testTwoLabeledSections() {
+  const name = 'Two labeled sections produce grouped ## Section headings';
+  const { tmpDir, outDir } = createTempSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'docs', routeBasePath: 'docs', label: 'Documentation' },
+        { path: 'api', routeBasePath: 'api', label: 'API Reference' },
+      ],
+      llmsTxtFilename: 'llms-test1.txt',
+      llmsFullTxtFilename: 'llms-full-test1.txt',
+    });
+    await p.postBuild();
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test1.txt'), 'utf8');
+
+    assert.ok(content.includes('## Documentation'), 'Expected ## Documentation heading');
+    assert.ok(content.includes('## API Reference'), 'Expected ## API Reference heading');
+    assert.ok(content.includes('Getting Started'), 'Expected Getting Started link');
+    assert.ok(content.includes('Authentication'), 'Expected Authentication link');
+
+    // Documentation heading should appear before API Reference heading
+    assert.ok(
+      content.indexOf('## Documentation') < content.indexOf('## API Reference'),
+      'Expected Documentation section before API Reference section'
+    );
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 2: Label fallback to path when no label provided
+async function testLabelFallbackToPath() {
+  const name = 'Label falls back to path when no label provided';
+  const { tmpDir, outDir } = createTempSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'docs', routeBasePath: 'docs' },
+        { path: 'api', routeBasePath: 'api' },
+      ],
+      llmsTxtFilename: 'llms-test2.txt',
+      llmsFullTxtFilename: 'llms-full-test2.txt',
+    });
+    await p.postBuild();
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test2.txt'), 'utf8');
+
+    assert.ok(content.includes('## docs'), 'Expected ## docs heading when no label');
+    assert.ok(content.includes('## api'), 'Expected ## api heading when no label');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 3: String docsDir still works (backward compatibility)
+async function testStringDocsDirBackwardCompat() {
+  const name = 'String docsDir remains backward-compatible';
+  const { tmpDir, outDir } = createTempSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: 'docs',
+      llmsTxtFilename: 'llms-test3.txt',
+      llmsFullTxtFilename: 'llms-full-test3.txt',
+    });
+    await p.postBuild();
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test3.txt'), 'utf8');
+
+    assert.ok(content.includes('Getting Started'), 'Expected docs content in output');
+    // Should NOT contain api content since we only specified docs
+    assert.ok(!content.includes('Authentication'), 'Should not include api content with string docsDir: docs');
+    // Should not contain section headings for single section
+    assert.ok(!content.includes('## docs'), 'Should not have section heading for single string docsDir');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 4: Single array entry works correctly (no section headings)
+async function testSingleArrayEntry() {
+  const name = 'Single array entry works correctly without section headings';
+  const { tmpDir, outDir } = createTempSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'api', routeBasePath: 'api', label: 'API Reference' },
+      ],
+      llmsTxtFilename: 'llms-test4.txt',
+      llmsFullTxtFilename: 'llms-full-test4.txt',
+    });
+    await p.postBuild();
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test4.txt'), 'utf8');
+
+    assert.ok(content.includes('Authentication'), 'Expected api content in output');
+    // Single section should NOT have section grouping headings
+    assert.ok(!content.includes('## API Reference'), 'Should not have section heading for single-entry array');
+    // Should not contain docs content
+    assert.ok(!content.includes('Getting Started'), 'Should not include docs content when only api section configured');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 5: Validation rejects invalid docsDir array entries
+async function testValidationRejectsInvalidArray() {
+  const name = 'Validation rejects invalid docsDir array entries';
+  try {
+    // Missing routeBasePath
+    assert.throws(
+      () => plugin(makeMockContext('/tmp', '/tmp/out'), {
+        docsDir: [{ path: 'docs' }],
+      }),
+      /docsDir\[0\]\.routeBasePath must be a non-empty string/,
+      'Expected error for missing routeBasePath'
+    );
+
+    // Missing path
+    assert.throws(
+      () => plugin(makeMockContext('/tmp', '/tmp/out'), {
+        docsDir: [{ routeBasePath: 'docs' }],
+      }),
+      /docsDir\[0\]\.path must be a non-empty string/,
+      'Expected error for missing path'
+    );
+
+    // Empty label
+    assert.throws(
+      () => plugin(makeMockContext('/tmp', '/tmp/out'), {
+        docsDir: [{ path: 'docs', routeBasePath: 'docs', label: '   ' }],
+      }),
+      /docsDir\[0\]\.label must be a non-empty string/,
+      'Expected error for whitespace-only label'
+    );
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  }
+}
+
+// Test 6: llms-full.txt contains content from all sections
+async function testFullTxtContainsBothSections() {
+  const name = 'llms-full.txt contains content from all sections';
+  const { tmpDir, outDir } = createTempSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'docs', routeBasePath: 'docs', label: 'Documentation' },
+        { path: 'api', routeBasePath: 'api', label: 'API Reference' },
+      ],
+      llmsTxtFilename: 'llms-test6.txt',
+      llmsFullTxtFilename: 'llms-full-test6.txt',
+    });
+    await p.postBuild();
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-full-test6.txt'), 'utf8');
+
+    assert.ok(content.includes('Getting Started'), 'Expected docs content in full output');
+    assert.ok(content.includes('Authentication'), 'Expected api content in full output');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+async function main() {
+  await testTwoLabeledSections();
+  await testLabelFallbackToPath();
+  await testStringDocsDirBackwardCompat();
+  await testSingleArrayEntry();
+  await testValidationRejectsInvalidArray();
+  await testFullTxtContainsBothSections();
+
+  console.log('\n' + '='.repeat(50));
+  console.log(`Test Results: ${passedTests}/${passedTests + failedTests} passed, ${failedTests} failed`);
+  console.log('='.repeat(50));
+
+  if (failedTests > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds support for `docsDir` as an array of section objects, enabling multi-docs Docusaurus setups to generate a single `llms.txt` with named sections.

Based on the work in #28 by @Konkrad — thank you for the contribution!

**New config:**
\`\`\`js
docsDir: [
  { path: 'docs', routeBasePath: 'docs', label: 'Documentation' },
  { path: 'api', routeBasePath: 'api', label: 'API Reference' },
]
\`\`\`

**Output in llms.txt:**
\`\`\`
## Documentation
- [Getting Started](https://example.com/docs/getting-started)

## API Reference
- [Authentication](https://example.com/api/authentication)
\`\`\`

Existing string `docsDir` configs are fully backward compatible.