### PR TITLE
Fix: skip import/export statements in description extraction

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -167,8 +167,9 @@ export async function processMarkdownFile(
     const paragraphs = resolvedContent.split('\n\n');
     for (const para of paragraphs) {
       const trimmedPara = para.trim();
-      // Skip empty paragraphs and headings
-      if (trimmedPara && !trimmedPara.startsWith('#')) {
+      // Skip empty paragraphs, headings, and import/export statements
+      const isImportOrExport = /^(import\s|export\s)/.test(trimmedPara);
+      if (trimmedPara && !trimmedPara.startsWith('#') && !isImportOrExport) {
         description = trimmedPara;
         break;
       }


### PR DESCRIPTION
## Problem

When `.mdx` files start with `import` statements before any content paragraph, the description extraction for `llms.txt` picks up the import line as the page description:

```
- [Concepts](https://docs.vectara.com/docs/agents/agent-concepts.md): import CodePanel from '@site/src/theme/CodePanel';
```

Instead of:

```
- [Concepts](https://docs.vectara.com/docs/agents/agent-concepts.md): Agents are autonomous systems that understand natural language and use tools...
```

This is because `excludeImports` is applied to the content body **after** description extraction runs (line ~221), so import lines still get picked up by the fallback description logic (line ~171).

Related: #9

## Fix

Added a check in the description extraction fallback (second priority) to skip paragraphs starting with `import` or `export` statements, consistent with how `excludeImports` handles content cleaning.

```typescript
const isImportOrExport = /^(import\s|export\s)/.test(trimmedPara);
if (trimmedPara && !trimmedPara.startsWith('#') && !isImportOrExport) {
```

## Testing

Tested against the [Vectara docs](https://docs.vectara.com) Docusaurus site (389 pages, ~215 affected `.mdx` files with imports). Before/after:

| Before | After |
|---|---|
| `[Concepts](...): import CodePanel from '@site/src/theme/CodePanel';` | `[Concepts](...): Agents are autonomous systems that understand natural language and use tools` |
| `[Built-in tools](...): import CodePanel from '@site/src/theme/CodePanel';` | `[Built-in tools](...): Tools provide agents with capabilities to interact with data and external` |