### PR TITLE
Fix baseUrl dropped from generated URLs (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the docusaurus-plugin-llms will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-07-13
+
+### Fixed
+
+- **baseUrl dropped from generated URLs** (#43) — sites deployed to a subpath (e.g. `baseUrl: '/docs/'`) had the base path silently discarded, producing links to the wrong location. The baseUrl pathname is now preserved on both the resolved-route and fallback code paths, and is added to a route only when not already present (so it's never dropped or duplicated).
+- **Trailing slash in `docsDir`** (#43) — a `docsDir` like `'foo/'` produced a doubled slash that prevented the prefix from being stripped. The prefix is now normalized before use.
+
 ## [0.4.1] - 2026-07-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docusaurus-plugin-llms",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Docusaurus plugin for generating LLM-friendly documentation following the llmstxt.org standard",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -9,7 +9,7 @@
     "watch": "tsc --watch",
     "cleanup": "node cleanup.js",
     "prepublishOnly": "npm run build && npm run cleanup",
-    "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
+    "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-baseurl-url-construction.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
     "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js",
     "test": "npm run build && npm run test:unit && npm run test:integration"
   },

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -80,12 +80,23 @@ export async function processMarkdownFile(
   let fullUrl: string;
 
   if (isNonEmptyString(resolvedUrl)) {
-    // Use the actual resolved URL from Docusaurus if provided
+    // Use the actual resolved route from Docusaurus. `siteUrl` already includes
+    // the site's baseUrl pathname (e.g. https://host/docs), which must be kept.
+    // `new URL(route, siteUrl)` would discard it whenever `route` is
+    // origin-relative, so assemble the URL manually. Docusaurus routes may or
+    // may not already carry the baseUrl prefix, so prepend it only when missing
+    // — this avoids both dropping it (issue #43) and duplicating it.
     try {
-      fullUrl = new URL(resolvedUrl, siteUrl).toString();
+      const base = new URL(siteUrl);
+      const basePath = base.pathname.replace(/\/+$/, ''); // '' for root, '/docs' otherwise
+      let routePath = resolvedUrl.startsWith('/') ? resolvedUrl : `/${resolvedUrl}`;
+      if (basePath && routePath !== basePath && !routePath.startsWith(`${basePath}/`)) {
+        routePath = `${basePath}${routePath}`;
+      }
+      fullUrl = `${base.origin}${routePath}`;
     } catch (error: unknown) {
       logger.warn(`Invalid URL construction: ${resolvedUrl} with base ${siteUrl}. Using fallback.`);
-      // Fallback to string concatenation with proper path joining
+      // Fallback to string concatenation. `siteUrl` retains its baseUrl pathname.
       const baseUrl = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
       const urlPath = resolvedUrl.startsWith('/') ? resolvedUrl : `/${resolvedUrl}`;
       fullUrl = baseUrl + urlPath;
@@ -100,21 +111,25 @@ export async function processMarkdownFile(
       ? linkPathBase.replace(/\/index$/, '') 
       : linkPathBase;
     
+    // pathPrefix may carry a trailing slash (e.g. docsDir: 'foo/'); normalize it
+    // so prefix matching and URL assembly never produce a doubled slash (#43).
+    const cleanPrefix = pathPrefix ? pathPrefix.replace(/\/+$/, '') : pathPrefix;
+
     // linkPath might include the pathPrefix (e.g., "docs/api/core")
     // We need to remove the pathPrefix before applying transformations, then add it back later
-    if (pathPrefix && linkPath.startsWith(`${pathPrefix}/`)) {
-      linkPath = linkPath.substring(`${pathPrefix}/`.length);
-    } else if (pathPrefix && linkPath === pathPrefix) {
+    if (cleanPrefix && linkPath.startsWith(`${cleanPrefix}/`)) {
+      linkPath = linkPath.substring(`${cleanPrefix}/`.length);
+    } else if (cleanPrefix && linkPath === cleanPrefix) {
       linkPath = '';
     }
-    
+
     // Apply path transformations to the clean link path (without pathPrefix)
     const transformedLinkPath = applyPathTransformations(linkPath, pathTransformation);
-    
+
     // Also apply path transformations to the pathPrefix if it's not empty
     // This allows removing 'docs' from the path when specified in ignorePaths
-    let transformedPathPrefix = pathPrefix;
-    if (pathPrefix && pathTransformation?.ignorePaths?.includes(pathPrefix)) {
+    let transformedPathPrefix = cleanPrefix;
+    if (cleanPrefix && pathTransformation?.ignorePaths?.includes(cleanPrefix)) {
       transformedPathPrefix = '';
     }
     
@@ -146,11 +161,15 @@ export async function processMarkdownFile(
     // We don't use URL constructor for the full path because it decodes some characters
     const pathPart = transformedPathPrefix ? `${transformedPathPrefix}/${encodedLinkPath}` : encodedLinkPath;
     try {
-      const baseUrl = new URL(siteUrl);
-      fullUrl = `${baseUrl.origin}/${pathPart}`;
+      // Preserve the baseUrl pathname carried by siteUrl; `.origin` alone would
+      // drop it (e.g. https://host/docs → https://host), breaking subpath
+      // deployments (#43).
+      const base = new URL(siteUrl);
+      const basePath = base.pathname.replace(/\/+$/, ''); // '' for root, '/docs' otherwise
+      fullUrl = `${base.origin}${basePath}/${pathPart}`;
     } catch (error: unknown) {
       logger.warn(`Invalid siteUrl: ${siteUrl}. Using fallback.`);
-      // Fallback to string concatenation with proper path joining
+      // Fallback to string concatenation. `siteUrl` retains its baseUrl pathname.
       const baseUrl = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
       fullUrl = `${baseUrl}/${pathPart}`;
     }

--- a/tests/test-baseurl-url-construction.js
+++ b/tests/test-baseurl-url-construction.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for full URL construction in processMarkdownFile, focused on baseUrl
+ * handling (issue #43): the site's baseUrl pathname must survive both the
+ * resolved-route path and the fallback path, and a trailing slash on the
+ * docsDir/pathPrefix must not produce doubled slashes or a dropped prefix.
+ *
+ * Run with: node test-baseurl-url-construction.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+const { processMarkdownFile } = require('../lib/processor');
+
+let passed = 0;
+let failed = 0;
+
+function makeDoc(dir, relPath, body = '# Title\n\nSome content.\n') {
+  const full = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+  return full;
+}
+
+async function check(name, { relPath, siteUrl, pathPrefix, resolvedUrl }, expectedUrl) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llms-baseurl-'));
+  try {
+    const filePath = makeDoc(tmpDir, relPath);
+    const doc = await processMarkdownFile(
+      filePath,
+      tmpDir,
+      siteUrl,
+      pathPrefix,
+      undefined,   // pathTransformation
+      false,       // excludeImports
+      false,       // removeDuplicateHeadings
+      resolvedUrl
+    );
+    assert.strictEqual(doc.url, expectedUrl);
+    assert.ok(!/([^:])\/\//.test(doc.url), `URL should not contain doubled slashes: ${doc.url}`);
+    console.log(`✅ PASS: ${name}\n   ${doc.url}`);
+    passed++;
+  } catch (err) {
+    console.log(`❌ FAIL: ${name}\n   ${err.message}`);
+    failed++;
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function run() {
+  console.log('Testing baseUrl-aware URL construction...\n');
+
+  // --- Resolved-route path (Docusaurus routesPaths available) ---
+
+  // Subpath baseUrl, route is baseUrl-relative → baseUrl must be prepended (#43.3)
+  await check('resolved route, subpath baseUrl, route without prefix', {
+    relPath: 'docs/explainers/foo.md',
+    siteUrl: 'https://noir-lang.org/docs',
+    pathPrefix: 'docs',
+    resolvedUrl: '/explainers/foo',
+  }, 'https://noir-lang.org/docs/explainers/foo');
+
+  // Same, but route already carries baseUrl → must NOT be duplicated
+  await check('resolved route, subpath baseUrl, route already prefixed', {
+    relPath: 'docs/explainers/foo.md',
+    siteUrl: 'https://noir-lang.org/docs',
+    pathPrefix: 'docs',
+    resolvedUrl: '/docs/explainers/foo',
+  }, 'https://noir-lang.org/docs/explainers/foo');
+
+  // Root baseUrl → unchanged behaviour
+  await check('resolved route, root baseUrl', {
+    relPath: 'docs/intro.md',
+    siteUrl: 'https://tunit.dev/',
+    pathPrefix: 'docs',
+    resolvedUrl: '/docs/intro',
+  }, 'https://tunit.dev/docs/intro');
+
+  // --- Fallback path (no resolvedUrl) ---
+
+  // Subpath baseUrl must be preserved (#43.2 — previously dropped by .origin)
+  await check('fallback, subpath baseUrl preserved', {
+    relPath: 'docs/guide.md',
+    siteUrl: 'https://example.com/base',
+    pathPrefix: 'docs',
+    resolvedUrl: undefined,
+  }, 'https://example.com/base/docs/guide');
+
+  // Trailing slash on pathPrefix must not break stripping or double the slash (#43.1)
+  await check('fallback, trailing-slash pathPrefix', {
+    relPath: 'docs/guide.md',
+    siteUrl: 'https://example.com/base',
+    pathPrefix: 'docs/',
+    resolvedUrl: undefined,
+  }, 'https://example.com/base/docs/guide');
+
+  // Root baseUrl fallback → unchanged behaviour
+  await check('fallback, root baseUrl', {
+    relPath: 'docs/guide.md',
+    siteUrl: 'https://example.com/',
+    pathPrefix: 'docs',
+    resolvedUrl: undefined,
+  }, 'https://example.com/docs/guide');
+
+  console.log(`\n========================================`);
+  console.log(`baseUrl URL Construction Tests Summary:`);
+  console.log(`Passed: ${passed}, Failed: ${failed}, Total: ${passed + failed}`);
+  console.log(`========================================\n`);
+  return failed === 0;
+}
+
+run()
+  .then(ok => {
+    console.log(ok ? '🎉 All baseUrl URL construction tests passed!' : '❌ Some tests failed.');
+    process.exit(ok ? 0 : 1);
+  })
+  .catch(err => {
+    console.error('Test execution error:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Fixes #43.

Sites deployed to a subpath (e.g. `baseUrl: '/docs/'`) had the base path silently dropped from the URLs in `llms.txt` / generated markdown, producing links to the wrong location.

- Preserve the baseUrl pathname (carried by `siteUrl`) on both the resolved-route path and the fallback path. `new URL(route, base)` and `URL.origin` were discarding it.
- Add the baseUrl to a route only when it isn't already present, so it's neither dropped nor duplicated regardless of whether Docusaurus routes include it.
- Normalize a trailing slash on `docsDir`/`pathPrefix` so it no longer produces a doubled slash that skipped prefix stripping.

Adds `test-baseurl-url-construction.js` (wired into `npm test`) covering subpath and root baseUrl on both paths. Full suite passes.

Likely also addresses the wrong-host links in #41 for subpath deployments.