### PR TITLE
Add useRelativeUrls option for origin-relative links (#37, #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the docusaurus-plugin-llms will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-07-13
+
+### Added
+
+- **`useRelativeUrls` option** (#37, #42) — opt-in (`false` by default) that emits origin-relative links in `llms.txt` (e.g. `/docs/page.md`) instead of absolute URLs. Useful for subpath deployments where the site `url` can't be pinned to the real deployment host. The baseUrl portion of the path is preserved.
+
 ## [0.4.2] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ module.exports = {
 | `rootContent`                    | string   | (see below)       | Custom content to include at the root level of llms.txt       |
 | `fullRootContent`                | string   | (see below)       | Custom content to include at the root level of llms-full.txt  |
 | `logLevel`                       | string   | `'normal'`        | Logging level for plugin output: `'quiet'`, `'normal'`, or `'verbose'` |
+| `useRelativeUrls`                | boolean  | `false`           | Emit origin-relative links in `llms.txt` (e.g. `/docs/page.md`) instead of absolute URLs — useful for subpath deployments where the site `url` can't be pinned |
 
 ### Custom Root Content
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docusaurus-plugin-llms",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Docusaurus plugin for generating LLM-friendly documentation following the llmstxt.org standard",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -9,7 +9,7 @@
     "watch": "tsc --watch",
     "cleanup": "node cleanup.js",
     "prepublishOnly": "npm run build && npm run cleanup",
-    "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-baseurl-url-construction.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
+    "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-baseurl-url-construction.js && node tests/test-relative-urls.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
     "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js",
     "test": "npm run build && npm run test:unit && npm run test:integration"
   },

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -54,6 +54,21 @@ function applyMdExtension(url: string): string {
 }
 
 /**
+ * Convert an absolute URL to an origin-relative one, keeping the path (which
+ * includes the site's baseUrl), query, and fragment — e.g.
+ * `https://site.com/docs/page.md` → `/docs/page.md`. Non-absolute or unparseable
+ * values are returned unchanged.
+ */
+function toRelativeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Generate an LLM-friendly file
  * @param docs - Processed document information
  * @param outputPath - Path to write the output file
@@ -74,7 +89,8 @@ export async function generateLLMFile(
   version?: string,
   customRootContent?: string,
   batchSize: number = 100,
-  addMdExtension: boolean = true
+  addMdExtension: boolean = true,
+  useRelativeUrls: boolean = false
 ): Promise<void> {
   // Validate path length before proceeding
   if (!validatePathLength(outputPath)) {
@@ -174,7 +190,8 @@ ${doc.content}`;
           sectionMap.set(sectionKey, []);
         }
         const cleanedDescription = cleanDescriptionForToc(doc.description);
-        const linkUrl = addMdExtension ? applyMdExtension(doc.url) : doc.url;
+        let linkUrl = addMdExtension ? applyMdExtension(doc.url) : doc.url;
+        if (useRelativeUrls) linkUrl = toRelativeUrl(linkUrl);
         sectionMap.get(sectionKey)!.push(
           `- [${doc.title}](${linkUrl})${cleanedDescription ? `: ${cleanedDescription}` : ''}`
         );
@@ -190,7 +207,8 @@ ${doc.content}`;
     } else {
       const tocItems = docs.map(doc => {
         const cleanedDescription = cleanDescriptionForToc(doc.description);
-        const linkUrl = addMdExtension ? applyMdExtension(doc.url) : doc.url;
+        let linkUrl = addMdExtension ? applyMdExtension(doc.url) : doc.url;
+        if (useRelativeUrls) linkUrl = toRelativeUrl(linkUrl);
         return `- [${doc.title}](${linkUrl})${cleanedDescription ? `: ${cleanedDescription}` : ''}`;
       });
       tocContent = `## Table of Contents\n\n${tocItems.join('\n')}`;
@@ -472,9 +490,10 @@ export async function generateStandardLLMFiles(
     rootContent,
     fullRootContent,
     processingBatchSize = 100,
-    addMdExtension = true
+    addMdExtension = true,
+    useRelativeUrls = false
   } = options;
-  
+
   if (!generateLLMsTxt && !generateLLMsFullTxt) {
     logger.warn('No standard LLM files configured for generation. Skipping.');
     return;
@@ -523,7 +542,8 @@ export async function generateStandardLLMFiles(
       version,
       rootContent,
       processingBatchSize,
-      addMdExtension
+      addMdExtension,
+      useRelativeUrls
     );
   }
 
@@ -539,7 +559,8 @@ export async function generateStandardLLMFiles(
       version,
       fullRootContent,
       processingBatchSize,
-      addMdExtension
+      addMdExtension,
+      useRelativeUrls
     );
   }
 }
@@ -559,9 +580,10 @@ export async function generateCustomLLMFiles(
     ignoreFiles = [],
     generateMarkdownFiles = false,
     processingBatchSize = 100,
-    addMdExtension = true
+    addMdExtension = true,
+    useRelativeUrls = false
   } = options;
-  
+
   if (customLLMFiles.length === 0) {
     logger.warn('No custom LLM files configured. Skipping.');
     return;
@@ -617,7 +639,8 @@ export async function generateCustomLLMFiles(
         customFile.version,
         customFile.rootContent,
         processingBatchSize,
-        addMdExtension
+        addMdExtension,
+        useRelativeUrls
       );
       
       logger.info(`Generated custom LLM file: ${customFile.filename} with ${customDocs.length} documents`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,6 +254,7 @@ export default function docusaurusPluginLLMs(
     processingBatchSize = 100,
     warnOnIgnoredFiles = false,
     rewriteImageUrls = false,
+    useRelativeUrls = false,
   } = options;
 
   // Normalize docsDir into docsSections array
@@ -323,6 +324,7 @@ export default function docusaurusPluginLLMs(
       processingBatchSize,
       warnOnIgnoredFiles,
       rewriteImageUrls,
+      useRelativeUrls,
     }
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,12 @@ export interface PluginOptions {
    *  (e.g., `https://site.com/assets/images/foo-abc123.png`) so LLMs can access the images. */
   rewriteImageUrls?: boolean;
 
+  /** Whether to emit origin-relative URLs instead of absolute ones (default: false).
+   *  When enabled, links in `llms.txt` use the path only — including the site's
+   *  baseUrl — e.g. `/docs/page.md` instead of `https://site.com/docs/page.md`.
+   *  Useful when the site can't pin a stable `url` (e.g. subpath deployments). */
+  useRelativeUrls?: boolean;
+
   /** Index signature for Docusaurus plugin compatibility */
   [key: string]: unknown;
 }

--- a/tests/test-relative-urls.js
+++ b/tests/test-relative-urls.js
@@ -1,0 +1,91 @@
+/**
+ * Tests for the `useRelativeUrls` option (issues #37, #42): when enabled, links
+ * in llms.txt are emitted origin-relative (path + baseUrl only) instead of
+ * absolute, so they resolve regardless of which host serves the site.
+ *
+ * Run with: node test-relative-urls.js
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+const { generateLLMFile } = require('../lib/generator');
+
+let passed = 0;
+let failed = 0;
+
+async function emit(docs, { addMdExtension = true, useRelativeUrls = false } = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llms-relurl-'));
+  const outPath = path.join(tmpDir, 'llms.txt');
+  await generateLLMFile(
+    docs,
+    outPath,
+    'Test',
+    'Test description',
+    false,        // links only
+    undefined,    // version
+    undefined,    // rootContent
+    100,          // batchSize
+    addMdExtension,
+    useRelativeUrls
+  );
+  const content = fs.readFileSync(outPath, 'utf8');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  return content;
+}
+
+function expect(name, condition, detail) {
+  if (condition) {
+    console.log(`✅ PASS: ${name}`);
+    passed++;
+  } else {
+    console.log(`❌ FAIL: ${name}\n   ${detail}`);
+    failed++;
+  }
+}
+
+async function run() {
+  console.log('Testing useRelativeUrls option...\n');
+
+  const flatDocs = [
+    { title: 'Page One', url: 'https://thunder.dev/thunder/docs/one', description: 'first', content: '' },
+  ];
+  const sectionedDocs = [
+    { title: 'Page Two', url: 'https://thunder.dev/thunder/docs/two', description: 'second', content: '', section: 'Guides' },
+  ];
+
+  // Default: absolute URLs preserved
+  const abs = await emit(flatDocs);
+  expect('default emits absolute URL', abs.includes('(https://thunder.dev/thunder/docs/one.md)'), abs);
+
+  // Enabled: origin-relative, keeps baseUrl and .md extension
+  const rel = await emit(flatDocs, { useRelativeUrls: true });
+  expect('relative link keeps baseUrl + .md', rel.includes('(/thunder/docs/one.md)'), rel);
+  expect('relative link drops scheme+host', !rel.includes('https://thunder.dev'), rel);
+
+  // Enabled without .md extension
+  const relNoMd = await emit(flatDocs, { useRelativeUrls: true, addMdExtension: false });
+  expect('relative link without .md', relNoMd.includes('(/thunder/docs/one)') && !relNoMd.includes('.md)'), relNoMd);
+
+  // Sectioned branch also converts
+  const relSection = await emit(sectionedDocs, { useRelativeUrls: true });
+  expect('relative link in sectioned output', relSection.includes('(/thunder/docs/two.md)'), relSection);
+  expect('sectioned output has heading', relSection.includes('## Guides'), relSection);
+
+  console.log(`\n========================================`);
+  console.log(`Relative URL Tests Summary:`);
+  console.log(`Passed: ${passed}, Failed: ${failed}, Total: ${passed + failed}`);
+  console.log(`========================================\n`);
+  return failed === 0;
+}
+
+run()
+  .then(ok => {
+    console.log(ok ? '🎉 All relative URL tests passed!' : '❌ Some tests failed.');
+    process.exit(ok ? 0 : 1);
+  })
+  .catch(err => {
+    console.error('Test execution error:', err);
+    process.exit(1);
+  });

--- a/tests/test-relative-urls.js
+++ b/tests/test-relative-urls.js
@@ -73,6 +73,20 @@ async function run() {
   expect('relative link in sectioned output', relSection.includes('(/thunder/docs/two.md)'), relSection);
   expect('sectioned output has heading', relSection.includes('## Guides'), relSection);
 
+  // Query string and fragment are preserved (addMdExtension off to isolate)
+  const queryDocs = [
+    { title: 'Page Q', url: 'https://thunder.dev/thunder/docs/one?tab=a#frag', description: 'q', content: '' },
+  ];
+  const relQuery = await emit(queryDocs, { useRelativeUrls: true, addMdExtension: false });
+  expect('relative link preserves query + fragment', relQuery.includes('(/thunder/docs/one?tab=a#frag)'), relQuery);
+
+  // Already-relative URLs pass through unchanged (catch branch)
+  const alreadyRelDocs = [
+    { title: 'Page R', url: '/thunder/docs/one', description: 'r', content: '' },
+  ];
+  const relPassthrough = await emit(alreadyRelDocs, { useRelativeUrls: true, addMdExtension: false });
+  expect('already-relative URL passes through unchanged', relPassthrough.includes('(/thunder/docs/one)'), relPassthrough);
+
   console.log(`\n========================================`);
   console.log(`Relative URL Tests Summary:`);
   console.log(`Passed: ${passed}, Failed: ${failed}, Total: ${passed + failed}`);


### PR DESCRIPTION
Closes #37, closes #42.

Adds an opt-in `useRelativeUrls` option (default `false`). When enabled, links in `llms.txt` are emitted origin-relative — e.g. `/thunder/docs/page.md` instead of `https://thunder.dev/thunder/docs/page.md`.

This helps subpath deployments (e.g. GitHub Pages) where the Docusaurus `url` can't be pinned to the real host, without needing a custom post-build plugin to rewrite URLs. The baseUrl portion of the path is preserved; only the scheme+host is dropped.

Works in both link modes (page URLs and generated `.md` file URLs) and in sectioned output. Adds `test-relative-urls.js` (wired into `npm test`) plus README and CHANGELOG entries. Full suite passes.