### PR TITLE
Only append .md to links when markdown files are generated (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the docusaurus-plugin-llms will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-07-13
+
+### Fixed
+
+- **`.md` links returning 404** (#41) — `addMdExtension` appended `.md` to `llms.txt` links by default, but the `.md` files are only produced when `generateMarkdownFiles` is enabled, so the links pointed to files that didn't exist. `.md` is now appended only when the markdown files are actually generated; otherwise links point to the normal doc routes.
+
 ## [0.4.3] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ module.exports = {
 | `customLLMFiles`                 | array    | `[]`              | Array of custom LLM file configurations                       |
 | `generateMarkdownFiles`          | boolean  | `false`           | Generate individual markdown files and link to them from llms.txt |
 | `keepFrontMatter`                | string[] | []                | Preserve selected front matter items when generating individual markdown files |
-| `addMdExtension`                 | boolean  | `true`            | Append `.md` to link URLs in `llms.txt` per the llmstxt.org spec |
+| `addMdExtension`                 | boolean  | `true`            | Append `.md` to link URLs in `llms.txt` per the llmstxt.org spec. Only takes effect when `generateMarkdownFiles` is enabled, since the `.md` files must exist to be linked |
 | `preserveDirectoryStructure`     | boolean  | `true`            | Preserve full directory structure in generated markdown files (e.g., `docs/server/config.md` instead of `server/config.md`) |
 | `processingBatchSize`            | number   | `100`             | Batch size for processing documents to prevent out-of-memory errors on large sites |
 | `rootContent`                    | string   | (see below)       | Custom content to include at the root level of llms.txt       |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docusaurus-plugin-llms",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Docusaurus plugin for generating LLM-friendly documentation following the llmstxt.org standard",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -10,7 +10,7 @@
     "cleanup": "node cleanup.js",
     "prepublishOnly": "npm run build && npm run cleanup",
     "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-baseurl-url-construction.js && node tests/test-relative-urls.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
-    "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js",
+    "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js && node tests/test-md-extension-generation.js",
     "test": "npm run build && npm run test:unit && npm run test:integration"
   },
   "files": [

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -530,6 +530,11 @@ export async function generateStandardLLMFiles(
     );
   }
   
+  // Only append `.md` to links when the individual markdown files are actually
+  // generated — otherwise the links point to files that don't exist and 404
+  // (issue #41). When generateMarkdownFiles is off, link to the normal routes.
+  const emitMdLinks = addMdExtension && generateMarkdownFiles;
+
   // Generate llms.txt
   if (generateLLMsTxt) {
     const llmsTxtPath = path.join(outDir, llmsTxtFilename);
@@ -542,7 +547,7 @@ export async function generateStandardLLMFiles(
       version,
       rootContent,
       processingBatchSize,
-      addMdExtension,
+      emitMdLinks,
       useRelativeUrls
     );
   }
@@ -559,7 +564,7 @@ export async function generateStandardLLMFiles(
       version,
       fullRootContent,
       processingBatchSize,
-      addMdExtension,
+      emitMdLinks,
       useRelativeUrls
     );
   }
@@ -628,6 +633,10 @@ export async function generateCustomLLMFiles(
       const customTitle = customFile.title || docTitle;
       const customDescription = customFile.description || docDescription;
       
+      // Only append `.md` to links when the markdown files are actually
+      // generated, so links never point to nonexistent files (issue #41).
+      const emitMdLinks = addMdExtension && generateMarkdownFiles;
+
       // Generate the custom LLM file
       const customFilePath = path.join(outDir, customFile.filename);
       await generateLLMFile(
@@ -639,7 +648,7 @@ export async function generateCustomLLMFiles(
         customFile.version,
         customFile.rootContent,
         processingBatchSize,
-        addMdExtension,
+        emitMdLinks,
         useRelativeUrls
       );
       

--- a/tests/test-md-extension-generation.js
+++ b/tests/test-md-extension-generation.js
@@ -1,0 +1,112 @@
+/**
+ * Integration test for issue #41: `.md` must only be appended to llms.txt links
+ * when the individual markdown files are actually generated. Otherwise the links
+ * point to files that don't exist in the build output and return 404.
+ *
+ * Run with: node tests/test-md-extension-generation.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const plugin = require('../lib/index').default;
+
+console.log('Testing .md extension / file-generation coupling (#41)...\n');
+
+let passed = 0;
+let failed = 0;
+
+function createTempSite() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-llms-md-'));
+  const outDir = path.join(tmpDir, 'out');
+  fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'docs', 'getting-started.md'),
+    '---\ntitle: Getting Started\ndescription: Start here.\n---\n\n# Getting Started\n\nStart here.'
+  );
+  return { tmpDir, outDir };
+}
+
+function mockContext(tmpDir, outDir) {
+  return {
+    siteDir: tmpDir,
+    siteConfig: { title: 'Test', tagline: 'T', url: 'https://example.com', baseUrl: '/' },
+    outDir,
+  };
+}
+
+async function run() {
+  // Case 1: default (addMdExtension true, generateMarkdownFiles false) → no .md, no files
+  {
+    const name = 'default: links have no .md and no markdown files are written';
+    const { tmpDir, outDir } = createTempSite();
+    try {
+      await plugin(mockContext(tmpDir, outDir), {
+        generateLLMsFullTxt: false,
+        llmsTxtFilename: 'llms.txt',
+      }).postBuild();
+      const content = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+      assert.ok(content.includes('(https://example.com/docs/getting-started)'), `expected plain route link, got:\n${content}`);
+      assert.ok(!content.includes('getting-started.md'), `link should not have .md, got:\n${content}`);
+      assert.ok(!fs.existsSync(path.join(outDir, 'docs', 'getting-started.md')), 'no .md file should be generated');
+      console.log(`  ✅ PASS: ${name}`); passed++;
+    } catch (err) {
+      console.log(`  ❌ FAIL: ${name}\n     ${err.message}`); failed++;
+    } finally { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  }
+
+  // Case 2: generateMarkdownFiles true → .md links AND the files exist
+  {
+    const name = 'generateMarkdownFiles: links have .md and the files are written';
+    const { tmpDir, outDir } = createTempSite();
+    try {
+      await plugin(mockContext(tmpDir, outDir), {
+        generateLLMsFullTxt: false,
+        generateMarkdownFiles: true,
+        llmsTxtFilename: 'llms.txt',
+      }).postBuild();
+      const content = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+      assert.ok(content.includes('(https://example.com/docs/getting-started.md)'), `expected .md link, got:\n${content}`);
+      assert.ok(fs.existsSync(path.join(outDir, 'docs', 'getting-started.md')), 'the .md file should be generated');
+      console.log(`  ✅ PASS: ${name}`); passed++;
+    } catch (err) {
+      console.log(`  ❌ FAIL: ${name}\n     ${err.message}`); failed++;
+    } finally { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  }
+
+  // Case 3: explicit addMdExtension:false with generation off → still no .md (unchanged)
+  {
+    const name = 'addMdExtension:false keeps plain routes';
+    const { tmpDir, outDir } = createTempSite();
+    try {
+      await plugin(mockContext(tmpDir, outDir), {
+        generateLLMsFullTxt: false,
+        addMdExtension: false,
+        llmsTxtFilename: 'llms.txt',
+      }).postBuild();
+      const content = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+      assert.ok(!content.includes('getting-started.md'), `link should not have .md, got:\n${content}`);
+      console.log(`  ✅ PASS: ${name}`); passed++;
+    } catch (err) {
+      console.log(`  ❌ FAIL: ${name}\n     ${err.message}`); failed++;
+    } finally { fs.rmSync(tmpDir, { recursive: true, force: true }); }
+  }
+
+  console.log(`\n========================================`);
+  console.log(`.md Extension Coupling Tests Summary:`);
+  console.log(`Passed: ${passed}, Failed: ${failed}, Total: ${passed + failed}`);
+  console.log(`========================================\n`);
+  return failed === 0;
+}
+
+run()
+  .then(ok => {
+    console.log(ok ? '🎉 All .md extension coupling tests passed!' : '❌ Some tests failed.');
+    process.exit(ok ? 0 : 1);
+  })
+  .catch(err => {
+    console.error('Test execution error:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
Closes #41.

By default `addMdExtension` appended `.md` to every `llms.txt` link, but the `.md` files are only produced when `generateMarkdownFiles` is enabled. So out of the box the links pointed to files that don't exist in the build output and returned 404 (as reported on tunit.dev).

Fix: couple the two — `.md` is appended only when `generateMarkdownFiles` is on. When it's off, links point to the normal doc routes, which Docusaurus serves. When it's on, the `.md` files exist and the links resolve.

Adds `test-md-extension-generation.js` (integration, wired into `npm test`) covering both defaults and the generate-on case, and clarifies the `addMdExtension` README entry.