### PR TITLE
feat: multi-version llms output via `versions` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the docusaurus-plugin-llms will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-07-17
+
+### Added
+
+- **Multi-version output** via a new `versions` option. Generate a separate set
+  of LLM files per documentation version, each written under its own
+  subdirectory with links scoped to that version's routes. Accepts an explicit
+  array of versions (`{ name, label, docsDir, path, customLLMFiles, includeOrder }`)
+  or `'auto'` to detect them from Docusaurus docs versioning (`versions.json` +
+  `versioned_docs/`). Omitting `versions` preserves the existing single-root
+  behavior. Unset per-version fields fall back to the top-level options.
+
 ## [0.4.5] - 2026-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ module.exports = {
 | `removeDuplicateHeadings`        | boolean  | `false`           | Remove redundant content that duplicates heading text         |
 | `rewriteImageUrls`               | boolean  | `false`           | Rewrite relative image paths to absolute hashed build-output URLs |
 | `title`                          | string   | Site title        | Custom title to use in generated files                        |
-| `version`                        | string   | `undefined`       | Global version to include in all generated files              |
+| `version`                        | string   | `undefined`       | Global version label to include in all generated files        |
+| `versions`                       | array \| `'auto'` | `undefined` | Generate version-scoped LLM files, one set per version (see [Multi-version output](#multi-version-output)) |
 | `customLLMFiles`                 | array    | `[]`              | Array of custom LLM file configurations                       |
 | `generateMarkdownFiles`          | boolean  | `false`           | Generate individual markdown files and link to them from llms.txt |
 | `keepFrontMatter`                | string[] | []                | Preserve selected front matter items when generating individual markdown files |
@@ -593,6 +594,75 @@ Version: 1.0.0
 
 This file contains all documentation content in a single document following the llmstxt.org standard.
 ```
+
+##### Multi-version output
+
+The `version` option above only stamps a label into the file body. To publish a
+**separate set of LLM files per documentation version** — each written under its
+own subdirectory and with links scoped to that version's routes — use the
+`versions` option.
+
+This is useful for sites that keep more than one version live at once (for
+example a `nightly` build at the site root and a `stable` build under `/stable`).
+Any field left unset on a version falls back to the matching top-level option
+(`docsDir`, `customLLMFiles`, `includeOrder`).
+
+**Explicit versions.** List each version with its source directory and output
+`path` (the subdirectory *and* the route prefix its links resolve to):
+
+```js
+plugins: [
+  [
+    'docusaurus-plugin-llms',
+    {
+      // Shared defaults inherited by every version:
+      customLLMFiles: [ /* llms-python.txt, ... */ ],
+
+      versions: [
+        // Source dir -> output + route prefix
+        { name: 'nightly', label: 'Nightly', docsDir: 'docs',                    path: '' },      // -> /llms.txt
+        { name: 'stable',  label: 'v26.4',   docsDir: 'versioned_docs/version-1', path: 'stable' }, // -> /stable/llms.txt
+        // Add as many versions as you need (e.g. 'main', '0.0.1', ...)
+      ],
+    }
+  ],
+]
+```
+
+Each version writes `llms.txt` (and any `customLLMFiles`) under `<path>/`, so the
+example above produces `/llms.txt` and `/stable/llms.txt`. Links in the stable
+files resolve to `/stable/...` URLs, and the root version's links stay at the
+root (they never leak into a versioned subtree).
+
+**Automatic detection.** Set `versions: 'auto'` to derive the list from
+Docusaurus docs versioning — the current (unversioned) docs plus every entry in
+`versions.json` (sourced from `versioned_docs/version-<id>/`). Labels and route
+paths are read from your docs config when available:
+
+```js
+plugins: [
+  [
+    'docusaurus-plugin-llms',
+    {
+      customLLMFiles: [ /* ... */ ],
+      versions: 'auto',
+    }
+  ],
+]
+```
+
+Each version entry accepts:
+
+| Field            | Type              | Default              | Description                                                        |
+|------------------|-------------------|----------------------|--------------------------------------------------------------------|
+| `name`           | string (required) | —                    | Version identifier (e.g. `'nightly'`, `'stable'`, `'0.0.1'`)        |
+| `label`          | string            | `name`               | Label written into the `Version:` line of generated files          |
+| `docsDir`        | string \| array   | top-level `docsDir`  | Source docs directory (or sections) for this version               |
+| `path`           | string            | `name`               | Output subdirectory and route prefix (`''` for the site root)      |
+| `customLLMFiles` | array             | top-level value      | Per-version custom LLM files                                       |
+| `includeOrder`   | string[]          | top-level value      | Per-version include order                                          |
+
+Omitting `versions` entirely preserves the default single-root behavior.
 
 ## Logging Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docusaurus-plugin-llms",
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "gray-matter": "4.0.3",
@@ -28,7 +28,7 @@
         "url": "https://github.com/sponsors/rachfop"
       },
       "peerDependencies": {
-        "@docusaurus/core": "3.0.0"
+        "@docusaurus/core": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-llms",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Docusaurus plugin for generating LLM-friendly documentation following the llmstxt.org standard",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -10,7 +10,7 @@
     "cleanup": "node cleanup.js",
     "prepublishOnly": "npm run build && npm run cleanup",
     "test:unit": "node tests/test-plugin-options-validation.js && node tests/test-plugin-validation-integration.js && node tests/test-regex-escaping.js && node tests/test-baseurl-handling.js && node tests/test-baseurl-url-construction.js && node tests/test-relative-urls.js && node tests/test-content-cleaning-fences.js && node tests/test-path-transforms.js && node tests/test-header-deduplication.js && node tests/test-import-removal.js && node tests/test-partials.js && node tests/test-site-alias-partials.js && node tests/test-missing-partials.js && node tests/test-circular-imports.js && node tests/test-root-content.js && node tests/test-rewrite-image-urls.js && node tests/test-filenames.js && node tests/test-url-encoding.js && node tests/test-nested-paths.js && node tests/test-filename-sanitization.js && node tests/test-yaml-encoding.js && node tests/test-url-error-handling.js && node tests/test-regex-lastindex.js && node tests/test-whitespace-paths.js && node tests/test-unique-identifier-iteration-limit.js && node tests/test-error-handling.js && node tests/test-file-io-error-handling.js && node tests/test-parallel-processing.js && node tests/test-path-length-validation.js && node tests/test-bom-handling.js && node tests/test-batch-processing.js && node tests/test-input-validation.js && node tests/test-add-md-extension.js && node tests/test-import-description-skip.js && node tests/test-filename-sanitization-improved.js",
-    "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js && node tests/test-md-extension-generation.js && node tests/test-regression-fixes.js",
+    "test:integration": "node tests/test-path-transformation.js && node tests/test-multi-doc.js && node tests/test-draft-integration.js && node tests/test-md-extension-generation.js && node tests/test-regression-fixes.js && node tests/test-multi-version.js",
     "test": "npm run build && npm run test:unit && npm run test:integration"
   },
   "files": [

--- a/src/files.ts
+++ b/src/files.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from 'fs/promises';
+import * as path from 'path';
 
 /**
  * Write content to a file
@@ -10,6 +11,9 @@ import * as fs from 'fs/promises';
  * @param data - Content to write
  */
 export async function writeFile(filePath: string, data: string): Promise<void> {
+  // Ensure the parent directory exists so version-scoped outputs (e.g.
+  // stable/llms.txt) can be written even when the subdirectory is new.
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
   return fs.writeFile(filePath, data, 'utf8');
 }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -469,14 +469,16 @@ export async function generateStandardLLMFiles(
   context: PluginContext,
   allDocFiles: string[]
 ): Promise<void> {
-  const { 
-    outDir, 
+  const {
+    outDir,
     siteUrl,
-    docTitle, 
-    docDescription, 
-    options 
+    docTitle,
+    docDescription,
+    options
   } = context;
-  
+  // Version-scoped output lands under a subdirectory of outDir (e.g. 'stable').
+  const versionedOutDir = path.join(outDir, context.outputSubdir || '');
+
   const {
     generateLLMsTxt,
     generateLLMsFullTxt,
@@ -521,14 +523,14 @@ export async function generateStandardLLMFiles(
     logger.info('Generating individual markdown files...');
     processedDocs = await generateIndividualMarkdownFiles(
       processedDocs,
-      outDir,
+      versionedOutDir,
       siteUrl,
       context.docsDir,
       context.options.keepFrontMatter || [],
       context.options.preserveDirectoryStructure !== false // Default to true
     );
   }
-  
+
   // Only append `.md` to links when the individual markdown files are actually
   // generated — otherwise the links point to files that don't exist and 404
   // (issue #41). When generateMarkdownFiles is off, link to the normal routes.
@@ -536,7 +538,7 @@ export async function generateStandardLLMFiles(
 
   // Generate llms.txt
   if (generateLLMsTxt) {
-    const llmsTxtPath = path.join(outDir, llmsTxtFilename);
+    const llmsTxtPath = path.join(versionedOutDir, llmsTxtFilename);
     await generateLLMFile(
       processedDocs,
       llmsTxtPath,
@@ -553,7 +555,7 @@ export async function generateStandardLLMFiles(
 
   // Generate llms-full.txt
   if (generateLLMsFullTxt) {
-    const llmsFullTxtPath = path.join(outDir, llmsFullTxtFilename);
+    const llmsFullTxtPath = path.join(versionedOutDir, llmsFullTxtFilename);
     await generateLLMFile(
       processedDocs,
       llmsFullTxtPath,
@@ -579,6 +581,7 @@ export async function generateCustomLLMFiles(
   allDocFiles: string[]
 ): Promise<void> {
   const { outDir, siteUrl, docTitle, docDescription, options } = context;
+  const versionedOutDir = path.join(outDir, context.outputSubdir || '');
   const {
     customLLMFiles = [],
     ignoreFiles = [],
@@ -620,31 +623,33 @@ export async function generateCustomLLMFiles(
         logger.info(`Generating individual markdown files for custom file: ${customFile.filename}...`);
         customDocs = await generateIndividualMarkdownFiles(
           customDocs,
-          outDir,
+          versionedOutDir,
           siteUrl,
           context.docsDir,
           context.options.keepFrontMatter || [],
           context.options.preserveDirectoryStructure !== false // Default to true
         );
       }
-      
+
       // Use custom title/description or fall back to defaults
       const customTitle = customFile.title || docTitle;
       const customDescription = customFile.description || docDescription;
-      
+
       // Only append `.md` to links when the markdown files are actually
       // generated, so links never point to nonexistent files (issue #41).
       const emitMdLinks = addMdExtension && generateMarkdownFiles;
 
-      // Generate the custom LLM file
-      const customFilePath = path.join(outDir, customFile.filename);
+      // Per-file `version` wins; otherwise a custom file inherits the current
+      // version's label so version-scoped outputs (stable/llms-python.txt) are
+      // labeled like their llms.txt.
+      const customFilePath = path.join(versionedOutDir, customFile.filename);
       await generateLLMFile(
         customDocs,
         customFilePath,
         customTitle,
         customDescription,
         customFile.fullContent,
-        customFile.version,
+        customFile.version ?? options.version,
         customFile.rootContent,
         processingBatchSize,
         emitMdLinks,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,9 @@
  */
 
 import * as path from 'path';
+import * as fs from 'fs';
 import type { LoadContext, Plugin, Props } from '@docusaurus/types';
-import { PluginOptions, PluginContext, CustomLLMFile, DocsSection } from './types';
+import { PluginOptions, PluginContext, CustomLLMFile, DocsSection, VersionConfig } from './types';
 import { collectDocFiles, generateStandardLLMFiles, generateCustomLLMFiles } from './generator';
 import { setLogLevel, LogLevel, logger, getErrorMessage, isDefined, isNonEmptyString, isNonEmptyArray, buildImageAssetMap } from './utils';
 
@@ -211,6 +212,221 @@ function validatePluginOptions(options: PluginOptions): void {
       }
     });
   }
+
+  // Validate versions
+  if (options.versions !== undefined) {
+    if (options.versions !== 'auto' && !Array.isArray(options.versions)) {
+      throw new Error("versions must be an array of version objects or 'auto'");
+    }
+    if (Array.isArray(options.versions)) {
+      if (options.versions.length === 0) {
+        throw new Error('versions must contain at least one version object');
+      }
+      const seenNames = new Set<string>();
+      const seenPaths = new Set<string>();
+      options.versions.forEach((version, index) => {
+        if (typeof version !== 'object' || version === null) {
+          throw new Error(`versions[${index}] must be an object`);
+        }
+        if (!isNonEmptyString(version.name)) {
+          throw new Error(`versions[${index}].name must be a non-empty string`);
+        }
+        if (seenNames.has(version.name)) {
+          throw new Error(`versions[${index}].name '${version.name}' is duplicated`);
+        }
+        seenNames.add(version.name);
+
+        if (isDefined(version.label) && !isNonEmptyString(version.label)) {
+          throw new Error(`versions[${index}].label must be a non-empty string`);
+        }
+        if (isDefined(version.path) && typeof version.path !== 'string') {
+          throw new Error(`versions[${index}].path must be a string`);
+        }
+        // Two versions writing to the same subdirectory would clobber each other.
+        const normalizedPath = normalizeVersionPath(
+          isDefined(version.path) ? (version.path as string) : version.name
+        );
+        if (seenPaths.has(normalizedPath)) {
+          throw new Error(
+            `versions[${index}] resolves to path '${normalizedPath || '/'}', which collides with another version`
+          );
+        }
+        seenPaths.add(normalizedPath);
+
+        if (
+          isDefined(version.docsDir) &&
+          typeof version.docsDir !== 'string' &&
+          !Array.isArray(version.docsDir)
+        ) {
+          throw new Error(
+            `versions[${index}].docsDir must be a string or an array of section objects`
+          );
+        }
+        if (isDefined(version.customLLMFiles) && !Array.isArray(version.customLLMFiles)) {
+          throw new Error(`versions[${index}].customLLMFiles must be an array`);
+        }
+        if (isDefined(version.includeOrder) && !Array.isArray(version.includeOrder)) {
+          throw new Error(`versions[${index}].includeOrder must be an array`);
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Normalize a version `path` into a bare subdirectory segment with no leading or
+ * trailing slashes. The root version normalizes to '' (the site root).
+ */
+function normalizeVersionPath(rawPath: string): string {
+  return rawPath.replace(/^\/+|\/+$/g, '');
+}
+
+/** A version whose defaults have been resolved against the top-level options. */
+interface ResolvedVersion {
+  name: string;
+  label?: string;
+  docsSections: DocsSection[];
+  /** Bare output subdirectory / route prefix ('' for the site root). */
+  pathPrefix: string;
+  customLLMFiles?: CustomLLMFile[];
+  includeOrder?: string[];
+}
+
+/** Normalize a `docsDir` value into sections, falling back to the top-level one. */
+function toDocsSections(
+  docsDir: string | DocsSection[] | undefined,
+  fallback: DocsSection[]
+): DocsSection[] {
+  if (docsDir === undefined) return fallback;
+  if (Array.isArray(docsDir)) {
+    return docsDir.length > 0 ? docsDir : fallback;
+  }
+  return [{ path: docsDir, routeBasePath: docsDir }];
+}
+
+/**
+ * Resolve the effective list of versions to generate. With no `versions` option
+ * this is a single root version reproducing the plugin's default behavior; an
+ * explicit array is used as-is; `'auto'` is detected from Docusaurus versioning.
+ * Each version inherits any unset field from the top-level options.
+ */
+function resolveVersions(
+  options: PluginOptions,
+  siteDir: string,
+  siteConfig: unknown,
+  defaultDocsSections: DocsSection[],
+  defaultDocsDir: string | DocsSection[] | undefined
+): ResolvedVersion[] {
+  const { versions } = options;
+
+  if (versions === undefined) {
+    return [
+      {
+        name: 'default',
+        label: isNonEmptyString(options.version) ? options.version : undefined,
+        docsSections: defaultDocsSections,
+        pathPrefix: '',
+        customLLMFiles: options.customLLMFiles,
+        includeOrder: options.includeOrder,
+      },
+    ];
+  }
+
+  const configs: VersionConfig[] =
+    versions === 'auto'
+      ? detectVersions(siteDir, siteConfig, defaultDocsDir)
+      : versions;
+
+  return configs.map(version => ({
+    name: version.name,
+    label: isNonEmptyString(version.label) ? version.label : version.name,
+    docsSections: toDocsSections(version.docsDir, defaultDocsSections),
+    pathPrefix: normalizeVersionPath(
+      isDefined(version.path) ? (version.path as string) : version.name
+    ),
+    customLLMFiles: version.customLLMFiles ?? options.customLLMFiles,
+    includeOrder: version.includeOrder ?? options.includeOrder,
+  }));
+}
+
+/**
+ * Read per-version label/path metadata from the Docusaurus docs config. The docs
+ * plugin may be configured via a preset or listed directly in `plugins`; both are
+ * scanned. Returns an empty map when nothing is found (best effort).
+ */
+function readDocsVersionMeta(
+  siteConfig: unknown
+): Record<string, { label?: string; path?: string }> {
+  const meta: Record<string, { label?: string; path?: string }> = {};
+  const collect = (versions: unknown): void => {
+    if (!versions || typeof versions !== 'object') return;
+    for (const [id, cfg] of Object.entries(versions as Record<string, unknown>)) {
+      const c = (cfg ?? {}) as { label?: unknown; path?: unknown };
+      meta[id] = {
+        label: typeof c.label === 'string' ? c.label : undefined,
+        path: typeof c.path === 'string' ? c.path : undefined,
+      };
+    }
+  };
+
+  const cfg = siteConfig as { presets?: unknown[]; plugins?: unknown[] };
+  const scanEntry = (entry: unknown): void => {
+    if (!Array.isArray(entry)) return;
+    const opts = entry[1] as { docs?: { versions?: unknown }; versions?: unknown } | undefined;
+    // Presets nest docs options under `docs`; a standalone content-docs plugin
+    // holds `versions` at the top level of its options object.
+    collect(opts?.docs?.versions);
+    collect(opts?.versions);
+  };
+  (cfg?.presets ?? []).forEach(scanEntry);
+  (cfg?.plugins ?? []).forEach(scanEntry);
+  return meta;
+}
+
+/**
+ * Detect versions from Docusaurus docs versioning: the current (unversioned)
+ * docs plus every entry in `versions.json` (sourced from
+ * `versioned_docs/version-<id>`). Labels and route paths come from the docs
+ * config when available, otherwise sensible defaults.
+ */
+function detectVersions(
+  siteDir: string,
+  siteConfig: unknown,
+  defaultDocsDir: string | DocsSection[] | undefined
+): VersionConfig[] {
+  let versionedIds: string[] = [];
+  try {
+    const raw = fs.readFileSync(path.join(siteDir, 'versions.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      versionedIds = parsed.filter((id): id is string => typeof id === 'string');
+    }
+  } catch {
+    // No versions.json — only the current (unversioned) docs exist.
+  }
+
+  const versionMeta = readDocsVersionMeta(siteConfig);
+  const configs: VersionConfig[] = [];
+
+  const currentMeta = versionMeta['current'] ?? {};
+  configs.push({
+    name: 'current',
+    label: currentMeta.label,
+    docsDir: defaultDocsDir ?? 'docs',
+    path: normalizeVersionPath(currentMeta.path ?? ''),
+  });
+
+  for (const id of versionedIds) {
+    const idMeta = versionMeta[id] ?? {};
+    configs.push({
+      name: id,
+      label: idMeta.label,
+      docsDir: `versioned_docs/version-${id}`,
+      path: normalizeVersionPath(idMeta.path ?? id),
+    });
+  }
+
+  return configs;
 }
 
 /**
@@ -340,45 +556,84 @@ export default function docusaurusPluginLLMs(
       logger.info('Generating LLM-friendly documentation...');
      
       try {
-        let enhancedContext = pluginContext;
-        
-        // If props are provided (Docusaurus 3.x+), pass the resolved route
-        // paths so route resolution can match files to their actual URLs
-        if (props?.routesPaths) {
-          logger.verbose(`routesPaths available: ${props.routesPaths.length} routes — sample: ${props.routesPaths.slice(0, 5).join(', ')}`);
-          enhancedContext = {
-            ...pluginContext,
-            routesPaths: props.routesPaths,
-          };
+        const routesPaths = props?.routesPaths;
+        if (routesPaths) {
+          logger.verbose(`routesPaths available: ${routesPaths.length} routes — sample: ${routesPaths.slice(0, 5).join(', ')}`);
         } else {
           logger.verbose('routesPaths NOT available in postBuild props — URL resolution will use file-path fallback');
         }
 
-        // Build image asset map when rewriteImageUrls is enabled
+        // Build the image asset map once when rewriteImageUrls is enabled; it is
+        // keyed off the build output and shared across all versions.
+        let imageAssetMap: Map<string, string[]> | undefined;
         if (rewriteImageUrls) {
           logger.verbose('Building image asset map for URL rewriting...');
-          const imageAssetMap = await buildImageAssetMap(enhancedContext.outDir);
+          imageAssetMap = await buildImageAssetMap(pluginContext.outDir);
           logger.verbose(`Image asset map: ${imageAssetMap.size} unique image basenames indexed`);
-          enhancedContext = { ...enhancedContext, imageAssetMap };
         }
-        
-        // Collect all document files
-        const allDocFiles = await collectDocFiles(enhancedContext);
-        
-        // Skip further processing if no documents were found
-        if (!isNonEmptyArray(allDocFiles)) {
-          logger.warn('No documents found to process. Skipping.');
-          return;
+
+        const resolvedVersions = resolveVersions(
+          options,
+          siteDir,
+          siteConfig,
+          docsSections,
+          docsDir
+        );
+        // Non-root versions each own a route-path prefix; the root version
+        // excludes these so its links don't leak into a versioned subtree.
+        const otherPrefixes = resolvedVersions
+          .map(v => v.pathPrefix)
+          .filter(prefix => prefix !== '');
+        const isMultiVersion = options.versions !== undefined;
+
+        for (const version of resolvedVersions) {
+          const routePrefix = version.pathPrefix ? `/${version.pathPrefix}` : '';
+          const versionContext: PluginContext = {
+            ...pluginContext,
+            routesPaths,
+            imageAssetMap,
+            docsSections: version.docsSections,
+            docsDir: version.docsSections[0].path,
+            outputSubdir: version.pathPrefix,
+            // Only scope routes in multi-version mode; the single default
+            // version keeps the original whole-site matching behavior.
+            routePrefix: isMultiVersion ? routePrefix : undefined,
+            siblingPrefixes: isMultiVersion
+              ? otherPrefixes
+                  .filter(prefix => prefix !== version.pathPrefix)
+                  .map(prefix => `/${prefix}`)
+              : undefined,
+            options: {
+              ...pluginContext.options,
+              version: version.label,
+              customLLMFiles: version.customLLMFiles,
+              includeOrder: version.includeOrder,
+            },
+          };
+
+          if (isMultiVersion) {
+            logger.info(
+              `Generating LLM files for version '${version.name}'` +
+                ` -> /${version.pathPrefix}`
+            );
+          }
+
+          const allDocFiles = await collectDocFiles(versionContext);
+          if (!isNonEmptyArray(allDocFiles)) {
+            logger.warn(
+              `No documents found for version '${version.name}'. Skipping.`
+            );
+            continue;
+          }
+
+          await generateStandardLLMFiles(versionContext, allDocFiles);
+          await generateCustomLLMFiles(versionContext, allDocFiles);
+
+          logger.info(
+            `Stats: ${allDocFiles.length} documents processed` +
+              (isMultiVersion ? ` for version '${version.name}'` : '')
+          );
         }
-        
-        // Process standard LLM files (llms.txt and llms-full.txt)
-        await generateStandardLLMFiles(enhancedContext, allDocFiles);
-        
-        // Process custom LLM files
-        await generateCustomLLMFiles(enhancedContext, allDocFiles);
-        
-        // Output overall statistics
-        logger.info(`Stats: ${allDocFiles.length} total available documents processed`);
       } catch (err: unknown) {
         logger.error(`Error generating LLM documentation: ${getErrorMessage(err)}`);
       }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -235,6 +235,39 @@ export async function processMarkdownFile(
 }
 
 /**
+ * Restrict a route list to the subtree owned by the current version.
+ *
+ * - With no prefix info (single-version default), returns routes unchanged.
+ * - A non-empty `routePrefix` (e.g. '/stable') keeps only routes under it.
+ * - The root version (empty prefix) drops routes owned by sibling versions,
+ *   so its links don't resolve into a versioned subtree.
+ */
+function scopeRoutesToVersion(
+  routesPaths: string[],
+  routePrefix?: string,
+  siblingPrefixes?: string[]
+): string[] {
+  const prefix = routePrefix ? routePrefix.replace(/\/+$/, '') : '';
+  if (prefix) {
+    return routesPaths.filter(
+      route => route === prefix || route.startsWith(`${prefix}/`)
+    );
+  }
+
+  const siblings = (siblingPrefixes ?? [])
+    .map(sibling => sibling.replace(/\/+$/, ''))
+    .filter(Boolean);
+  if (siblings.length === 0) return routesPaths;
+
+  return routesPaths.filter(
+    route =>
+      !siblings.some(
+        sibling => route === sibling || route.startsWith(`${sibling}/`)
+      )
+  );
+}
+
+/**
  * Find the best matching route for a given path tail using suffix matching.
  * This avoids needing to know about version prefixes, baseUrl, or other
  * routing details — any route ending with the tail is a match.
@@ -304,6 +337,16 @@ async function resolveDocumentUrl(
 
   const { docsDir } = context;
 
+  // In multi-version mode, restrict matching to routes owned by this version so
+  // links resolve within the correct subtree (e.g. a 'stable' doc links to
+  // /stable/... and the root version's links avoid versioned subtrees).
+  const scopedRoutes = scopeRoutesToVersion(
+    context.routesPaths,
+    context.routePrefix,
+    context.siblingPrefixes
+  );
+  if (!scopedRoutes.length) return undefined;
+
   const relative = normalizePath(path.relative(baseDir, filePath))
     .replace(/\.mdx?$/, '')
     .replace(/\/index$/, '');
@@ -325,7 +368,7 @@ async function resolveDocumentUrl(
   if (stripped !== tail) tails.add(stripped);
 
   for (const t of tails) {
-    const match = findMatchingRoute(context.routesPaths, t);
+    const match = findMatchingRoute(scopedRoutes, t);
     if (match) return match;
   }
 
@@ -366,7 +409,7 @@ async function resolveDocumentUrl(
       if (!isNonEmptyString(slug)) continue;
       const parentDir = path.dirname(tail);
       const overriddenTail = parentDir === '.' ? slug : `${parentDir}/${slug}`;
-      const match = findMatchingRoute(context.routesPaths, overriddenTail);
+      const match = findMatchingRoute(scopedRoutes, overriddenTail);
       if (match) return match;
     }
   } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,37 @@ export interface CustomLLMFile {
 }
 
 /**
+ * Configuration for a single documentation version.
+ *
+ * When `versions` is set, the plugin runs its full generation pipeline once per
+ * version, writing each version's files under its own `path` subdirectory and
+ * resolving links against that version's routes. Any field left unset falls back
+ * to the corresponding top-level plugin option.
+ */
+export interface VersionConfig {
+  /** Version identifier (e.g. 'nightly', 'stable', 'main', '0.0.1'). */
+  name: string;
+  /** Human-readable label for the `Version:` metadata line (defaults to `name`). */
+  label?: string;
+  /**
+   * Source docs directory (or sections) for this version, relative to siteDir
+   * (e.g. 'docs' for the current version, 'versioned_docs/version-1' for a
+   * versioned one). Defaults to the top-level `docsDir`.
+   */
+  docsDir?: string | DocsSection[];
+  /**
+   * Output subdirectory and route prefix for this version (e.g. '' for the site
+   * root, 'stable', '0.0.1'). Files are written to `<outDir>/<path>/` and links
+   * resolve to routes under `/<path>/`. Defaults to `name`.
+   */
+  path?: string;
+  /** Per-version custom LLM files (defaults to the top-level `customLLMFiles`). */
+  customLLMFiles?: CustomLLMFile[];
+  /** Per-version include order (defaults to the top-level `includeOrder`). */
+  includeOrder?: string[];
+}
+
+/**
  * Plugin options interface
  */
 export interface PluginOptions {
@@ -158,6 +189,13 @@ export interface PluginOptions {
    *  Useful when the site can't pin a stable `url` (e.g. subpath deployments). */
   useRelativeUrls?: boolean;
 
+  /**
+   * Generate version-scoped LLM files. Provide an explicit array of versions, or
+   * `'auto'` to detect them from Docusaurus docs versioning (versions.json +
+   * versioned_docs/). Omit for the default single-root behavior.
+   */
+  versions?: VersionConfig[] | 'auto';
+
   /** Index signature for Docusaurus plugin compatibility */
   [key: string]: unknown;
 }
@@ -178,4 +216,19 @@ export interface PluginContext {
    *  Built once per postBuild run when rewriteImageUrls is true. */
   imageAssetMap?: Map<string, string[]>;
   docsSections: DocsSection[];
-} 
+  /**
+   * Output subdirectory (relative to outDir) for the version being generated.
+   * Empty/undefined writes to the site root (the default).
+   */
+  outputSubdir?: string;
+  /**
+   * Route prefix (e.g. '/stable') the current version's URLs must fall under.
+   * Empty/undefined means the root version.
+   */
+  routePrefix?: string;
+  /**
+   * Route prefixes owned by other versions. When resolving the root version's
+   * URLs, routes under these prefixes are excluded so links stay at the root.
+   */
+  siblingPrefixes?: string[];
+}

--- a/tests/test-multi-version.js
+++ b/tests/test-multi-version.js
@@ -1,0 +1,300 @@
+/**
+ * Integration tests for multi-version support (the `versions` option).
+ *
+ * Covers explicit version arrays, `versions: 'auto'` detection, version-scoped
+ * output paths and links, backward compatibility, and validation.
+ *
+ * Run with: node tests/test-multi-version.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const pluginModule = require('../lib/index');
+const plugin = pluginModule.default;
+
+console.log('Testing multi-version support...\n');
+
+let passedTests = 0;
+let failedTests = 0;
+
+function pass(name) {
+  console.log(`  PASS: ${name}`);
+  passedTests++;
+}
+
+function fail(name, reason) {
+  console.log(`  FAIL: ${name}`);
+  console.log(`     ${reason}`);
+  failedTests++;
+}
+
+function page(title, body) {
+  return `---\ntitle: ${title}\ndescription: ${title} page.\n---\n\n# ${title}\n\n${body}`;
+}
+
+function makeMockContext(tmpDir, outDir, siteConfig = {}) {
+  return {
+    siteDir: tmpDir,
+    siteConfig: {
+      title: 'Test Site',
+      tagline: 'Testing versions',
+      url: 'https://example.com',
+      baseUrl: '/',
+      ...siteConfig,
+    },
+    outDir,
+  };
+}
+
+function makeSite() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-llms-ver-'));
+  const outDir = path.join(tmpDir, 'out');
+  fs.mkdirSync(outDir, { recursive: true });
+  return { tmpDir, outDir };
+}
+
+function cleanup(tmpDir) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+// Routes for a site whose single "get-started" page exists in both the current
+// and the stable version.
+const ROUTES = ['/', '/get-started', '/stable', '/stable/get-started'];
+
+// Test 1: Explicit versions array writes to per-version subdirs with scoped links
+async function testExplicitVersions() {
+  const name = 'Explicit versions write scoped files and links';
+  const { tmpDir, outDir } = makeSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'stable-docs'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'get-started.md'), page('Get Started', 'Nightly body.'));
+    fs.writeFileSync(path.join(tmpDir, 'stable-docs', 'get-started.md'), page('Get Started', 'Stable body.'));
+
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      generateLLMsFullTxt: false,
+      customLLMFiles: [
+        { filename: 'llms-guide.txt', title: 'Guide', description: 'Guide.', includePatterns: ['get-started.md'], fullContent: false },
+      ],
+      versions: [
+        { name: 'nightly', label: 'Nightly', docsDir: 'docs', path: '' },
+        { name: 'v26.4', label: 'v26.4', docsDir: 'stable-docs', path: 'stable' },
+      ],
+    });
+    await p.postBuild({ routesPaths: ROUTES });
+
+    const root = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+    const stable = fs.readFileSync(path.join(outDir, 'stable', 'llms.txt'), 'utf8');
+
+    assert.ok(root.includes('Version: Nightly'), 'root file should carry the Nightly label');
+    assert.ok(stable.includes('Version: v26.4'), 'stable file should carry the v26.4 label');
+
+    // Each version generates its custom files too, labeled with the version.
+    const rootGuide = fs.readFileSync(path.join(outDir, 'llms-guide.txt'), 'utf8');
+    const stableGuide = fs.readFileSync(path.join(outDir, 'stable', 'llms-guide.txt'), 'utf8');
+    assert.ok(rootGuide.includes('Version: Nightly'), 'root custom file should inherit the Nightly label');
+    assert.ok(stableGuide.includes('Version: v26.4'), 'stable custom file should inherit the v26.4 label');
+
+    // Links are version-scoped: root -> /get-started, stable -> /stable/get-started.
+    // (No .md suffix by default, since generateMarkdownFiles is off — issue #41.)
+    assert.ok(root.includes('/get-started'), 'root should link to /get-started');
+    assert.ok(!root.includes('/stable/'), 'root links should not leak into /stable/');
+    assert.ok(stable.includes('/stable/get-started'), 'stable should link to /stable/get-started');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 2: versions: 'auto' detects current + versioned docs from Docusaurus
+async function testAutoDetection() {
+  const name = "versions: 'auto' detects current + versioned docs";
+  const { tmpDir, outDir } = makeSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'versioned_docs', 'version-1'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'get-started.md'), page('Get Started', 'Nightly body.'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'versioned_docs', 'version-1', 'get-started.md'),
+      page('Get Started', 'Stable body.')
+    );
+    fs.writeFileSync(path.join(tmpDir, 'versions.json'), JSON.stringify(['1']));
+
+    const siteConfig = {
+      presets: [
+        [
+          'classic',
+          {
+            docs: {
+              versions: {
+                current: { label: 'Nightly', path: '/' },
+                1: { label: 'v26.4', path: '/stable' },
+              },
+            },
+          },
+        ],
+      ],
+    };
+
+    const p = plugin(makeMockContext(tmpDir, outDir, siteConfig), {
+      generateLLMsFullTxt: false,
+      versions: 'auto',
+    });
+    await p.postBuild({ routesPaths: ROUTES });
+
+    const root = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+    const stable = fs.readFileSync(path.join(outDir, 'stable', 'llms.txt'), 'utf8');
+
+    assert.ok(root.includes('Version: Nightly'), 'auto: root should use the Nightly label from config');
+    assert.ok(stable.includes('Version: v26.4'), 'auto: stable should use the v26.4 label from config');
+    assert.ok(stable.includes('/stable/get-started'), 'auto: stable should link into /stable/');
+    assert.ok(!root.includes('/stable/'), 'auto: root links should not leak into /stable/');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 3: omitting `versions` reproduces single-root behavior (no subdirs)
+async function testBackwardCompat() {
+  const name = 'Omitting versions keeps single-root behavior';
+  const { tmpDir, outDir } = makeSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'get-started.md'), page('Get Started', 'Body.'));
+
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      generateLLMsFullTxt: false,
+      docsDir: 'docs',
+    });
+    await p.postBuild({ routesPaths: ['/get-started'] });
+
+    assert.ok(fs.existsSync(path.join(outDir, 'llms.txt')), 'root llms.txt should exist');
+    assert.ok(!fs.existsSync(path.join(outDir, 'stable')), 'no version subdir should be created');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 4: validation rejects malformed versions options
+async function testValidation() {
+  const name = 'Validation rejects malformed versions';
+  try {
+    const ctx = () => makeMockContext('/tmp', '/tmp/out');
+
+    assert.throws(
+      () => plugin(ctx(), { versions: 123 }),
+      /versions must be an array of version objects or 'auto'/,
+      'non-array, non-auto value should throw'
+    );
+    assert.throws(
+      () => plugin(ctx(), { versions: [] }),
+      /versions must contain at least one version object/,
+      'empty array should throw'
+    );
+    assert.throws(
+      () => plugin(ctx(), { versions: [{ path: 'x' }] }),
+      /versions\[0\]\.name must be a non-empty string/,
+      'missing name should throw'
+    );
+    assert.throws(
+      () => plugin(ctx(), { versions: [{ name: 'a' }, { name: 'a' }] }),
+      /versions\[1\]\.name 'a' is duplicated/,
+      'duplicate name should throw'
+    );
+    assert.throws(
+      () => plugin(ctx(), { versions: [{ name: 'a', path: 'x' }, { name: 'b', path: 'x' }] }),
+      /collides with another version/,
+      'colliding paths should throw'
+    );
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  }
+}
+
+// Test 5: versions: 'auto' reads version metadata from a standalone
+// plugin-content-docs entry (as opposed to a preset), the shape used when docs
+// are configured via `plugins` with `docs: false` in the preset.
+async function testAutoDetectionFromPlugins() {
+  const name = "versions: 'auto' reads metadata from a plugins content-docs entry";
+  const { tmpDir, outDir } = makeSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'versioned_docs', 'version-1'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'docs', 'get-started.md'), page('Get Started', 'Nightly body.'));
+    fs.writeFileSync(
+      path.join(tmpDir, 'versioned_docs', 'version-1', 'get-started.md'),
+      page('Get Started', 'Stable body.')
+    );
+    fs.writeFileSync(path.join(tmpDir, 'versions.json'), JSON.stringify(['1']));
+
+    // docs configured as a standalone plugin (preset has docs: false).
+    const siteConfig = {
+      presets: [['classic', { docs: false }]],
+      plugins: [
+        [
+          '@docusaurus/plugin-content-docs',
+          {
+            versions: {
+              current: { label: 'Nightly', path: '/' },
+              1: { label: 'v26.4', path: '/stable' },
+            },
+          },
+        ],
+      ],
+    };
+
+    const p = plugin(makeMockContext(tmpDir, outDir, siteConfig), {
+      generateLLMsFullTxt: false,
+      versions: 'auto',
+    });
+    await p.postBuild({ routesPaths: ROUTES });
+
+    const root = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+    const stable = fs.readFileSync(path.join(outDir, 'stable', 'llms.txt'), 'utf8');
+    assert.ok(root.includes('Version: Nightly'), 'plugins auto: root uses Nightly label');
+    assert.ok(stable.includes('Version: v26.4'), 'plugins auto: stable uses v26.4 label');
+    assert.ok(stable.includes('/stable/get-started'), 'plugins auto: stable links into /stable/');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+async function main() {
+  await testExplicitVersions();
+  await testAutoDetection();
+  await testAutoDetectionFromPlugins();
+  await testBackwardCompat();
+  await testValidation();
+
+  console.log('\n' + '='.repeat(50));
+  console.log(`Test Results: ${passedTests}/${passedTests + failedTests} passed, ${failedTests} failed`);
+  console.log('='.repeat(50));
+
+  if (failedTests > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a `versions` plugin option to generate a separate set of LLM files per documentation version. Each version runs the full pipeline — writing `llms.txt` and every `customLLMFiles` entry under its own subdirectory, with links scoped to that version's routes.

`versions` accepts either:
- an **explicit array** — `{ name, label?, docsDir?, path?, customLLMFiles?, includeOrder? }` per version, or
- **`'auto'`** — detected from Docusaurus docs versioning (`versions.json` + `versioned_docs/`), reading labels/paths from the docs config (preset or standalone `plugin-content-docs`).

Unset per-version fields fall back to the top-level options. Omitting `versions` preserves the existing single-root behavior exactly.

## Why

Sites that keep more than one docs version live at once (e.g. a nightly build at the root and a stable build under `/stable`) currently get only a single root `llms.txt` covering the default version. This lets each version publish its own machine-readable index at `/<path>/llms.txt`.

## Notes

- Custom files now inherit the version label (`customFile.version ?? version`) so version-scoped outputs like `stable/llms-python.txt` are labeled consistently with their `llms.txt`.
- `writeFile` now creates parent directories so version subdirectories are written.
- Route resolution is scoped per version: versioned files link within their subtree, and the root version excludes versioned subtrees so its links don't leak.

## Test plan

`npm test` — adds `tests/test-multi-version.js` covering explicit arrays, `'auto'` (both preset- and plugins-based content-docs config), backward compatibility, validation, scoped links, and custom-file labeling. Full suite green.