### PR TITLE
Resolve @site partials via siteDir instead of process.cwd()

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -84,12 +84,14 @@ function escapeRegex(str: string): string {
  * @param content - The markdown content with import statements
  * @param filePath - The path of the file containing the imports
  * @param importChain - Set of file paths in the current import chain (for circular dependency detection)
+ * @param siteDir - Site root, used to resolve `@site/` alias imports (defaults to process.cwd())
  * @returns Content with partials resolved
  */
 export async function resolvePartialImports(
   content: string,
   filePath: string,
-  importChain: Set<string> = new Set()
+  importChain: Set<string> = new Set(),
+  siteDir: string = process.cwd()
 ): Promise<string> {
   let resolved = content;
 
@@ -119,11 +121,10 @@ export async function resolvePartialImports(
   for (const [componentName, importPath] of imports) {
     try {
       // Resolve the partial file path relative to the current file, or
-      // against the site directory for '@site/' alias imports. Docusaurus
-      // runs builds from the site directory, so cwd is the site root.
+      // against the site directory for '@site/' alias imports.
       const dir = path.dirname(filePath);
       const partialPath = importPath.startsWith('@site/')
-        ? path.resolve(process.cwd(), importPath.slice('@site/'.length))
+        ? path.resolve(siteDir, importPath.slice('@site/'.length))
         : path.resolve(dir, importPath);
 
       // Check for circular import
@@ -157,7 +158,7 @@ export async function resolvePartialImports(
       const { content: partialMarkdown } = matter(partialContent);
 
       // Recursively resolve imports in the partial with the updated chain
-      const resolvedPartial = await resolvePartialImports(partialMarkdown, partialPath, newChain);
+      const resolvedPartial = await resolvePartialImports(partialMarkdown, partialPath, newChain, siteDir);
 
       // Escape special regex characters in component name and import path
       const escapedComponentName = escapeRegex(componentName);

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -42,7 +42,8 @@ export async function processMarkdownFile(
   removeDuplicateHeadings: boolean = false,
   resolvedUrl?: string,
   imageAssetMap?: Map<string, string[]>,
-  outDir?: string
+  outDir?: string,
+  siteDir?: string
 ): Promise<DocInfo | null> {
   const content = await readFile(filePath);
   const { data, content: markdownContent } = matter(content);
@@ -73,7 +74,7 @@ export async function processMarkdownFile(
   }
   
   // Resolve partial imports before processing
-  const resolvedContent = await resolvePartialImports(markdownContent, filePath);
+  const resolvedContent = await resolvePartialImports(markdownContent, filePath, new Set(), siteDir);
   
   const relativePath = path.relative(baseDir, filePath);
   // Convert to URL path format (replace backslashes with forward slashes on Windows)
@@ -520,7 +521,8 @@ export async function processFilesWithPatterns(
           context.options.removeDuplicateHeadings || false,
           resolvedUrl,
           context.imageAssetMap,
-          context.options.rewriteImageUrls ? context.outDir : undefined
+          context.options.rewriteImageUrls ? context.outDir : undefined,
+          siteDir
         );
 
         if (docInfo && sectionLabel) {

--- a/tests/test-site-alias-partials.js
+++ b/tests/test-site-alias-partials.js
@@ -14,6 +14,7 @@
 
 const fs = require('fs').promises;
 const path = require('path');
+const os = require('os');
 const { processMarkdownFile } = require('../lib/processor');
 
 async function setupTestFiles() {
@@ -73,10 +74,11 @@ async function runTest() {
 
   const siteDir = await setupTestFiles();
 
-  // Docusaurus runs builds from the site directory, and @site resolution
-  // relies on that — mirror it here.
+  // Deliberately run from a cwd that is NOT the site directory, so the test
+  // proves `@site` resolves via the explicit siteDir argument rather than
+  // process.cwd().
   const originalCwd = process.cwd();
-  process.chdir(siteDir);
+  process.chdir(os.tmpdir());
 
   try {
     const docPath = path.join(siteDir, 'docs', 'editing.mdx');
@@ -86,7 +88,12 @@ async function runTest() {
       'https://example.com',
       'docs',
       undefined,
-      true // excludeImports
+      true, // excludeImports
+      false, // removeDuplicateHeadings
+      undefined, // resolvedUrl
+      undefined, // imageAssetMap
+      undefined, // outDir
+      siteDir // siteDir — used to resolve @site/ imports
     );
 
     let allTestsPassed = true;

--- a/tests/test-site-alias-partials.js
+++ b/tests/test-site-alias-partials.js
@@ -131,9 +131,7 @@ async function runTest() {
       console.log('✅ Test 4 passed: partial resolved in list context too');
     }
 
-    // Test 5: relative underscore convention still works (regression guard)
-    // — covered by test-partials.js; here we just confirm the doc's own
-    // content survived processing.
+    // Test 5: the surrounding document content survives processing.
     if (!result.content.includes('Make your changes.')) {
       console.log('❌ Test 5 failed: surrounding document content lost');
       allTestsPassed = false;


### PR DESCRIPTION
Follow-up to #55 (the review fix that didn't make it into that merge).

## What

Thread the site directory through `processMarkdownFile` into `resolvePartialImports` so `@site/` alias imports resolve against the real site root, instead of assuming the build runs from `process.cwd()`. Falls back to `process.cwd()` when no `siteDir` is supplied (keeps standalone/test usage working).

## Why

#55 resolved `@site/` partials using `process.cwd()`, which is correct for a normal Docusaurus build but fragile if the build runs from a different cwd. The plugin already knows the true `siteDir` (`context.siteDir`) — this passes it down.

## Test plan

Updates `tests/test-site-alias-partials.js` to run from a cwd that is **not** the site dir and pass `siteDir` explicitly, so it exercises the threaded argument rather than the cwd fallback. Full `npm test` passes.