### PR TITLE
fix: upgrade shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "gray-matter": "4.0.3",
         "minimatch": "9.0.3",
+        "shell-quote": "^1.8.4",
         "yaml": "2.8.1"
       },
       "devDependencies": {
@@ -14103,11 +14104,10 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "gray-matter": "4.0.3",
     "minimatch": "9.0.3",
+    "shell-quote": "^1.8.4",
     "yaml": "2.8.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Upgrade shell-quote from 1.8.2 to 1.8.4 to fix CVE-2026-9277.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-9277 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-9277` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: shell-quote: shell-quote: Arbitrary code execution via command injection due to unescaped line terminators

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-9277` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `package.json`
- `package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
