### PR TITLE
docs: fix CustomLLMFile.includeUnmatchedLast JSDoc default

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface CustomLLMFile {
   /** Order patterns for controlling file ordering (similar to includeOrder) */
   orderPatterns?: string[];
   
-  /** Whether to include unmatched files last (default: false) */
+  /** Whether to include unmatched files last (default: true) */
   includeUnmatchedLast?: boolean;
   
   /** Version information for this LLM file */


### PR DESCRIPTION
The JSDoc for `CustomLLMFile.includeUnmatchedLast` in `src/types.ts` said `(default: false)`, but the runtime default is `true`:

- `src/generator.ts` applies `customFile.includeUnmatchedLast ?? true`.
- `CHANGELOG.md` (0.4.5) documents the deliberate switch to `true`, so `includePatterns`-selected docs aren't dropped when `orderPatterns` doesn't list them.
- The top-level `includeUnmatchedLast` JSDoc already correctly says `true`.

Comment-only change, no runtime behavior change. Surfaced while splitting the README into `docs/` (#61).