### PR TITLE
fix: resolve absolute slugs that flatten a page out of its folder

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -398,8 +398,17 @@ async function resolveDocumentUrl(
 
       const slug = rawSlug.replace(/^\/+|\/+$/g, '');
       if (!isNonEmptyString(slug)) continue;
+      // A leading-slash slug is *absolute*: Docusaurus resolves it against the
+      // docs instance's routeBasePath, independent of where the file lives, so
+      // it must not be prefixed with the file's parent directory. Prefixing
+      // would break pages deliberately flattened out of their folder (e.g.
+      // `slug: /page` in docs/section/page.md routes to /page, not
+      // /section/page). A slug without a leading slash stays relative to the
+      // file's directory.
       const parentDir = path.dirname(tail);
-      const overriddenTail = parentDir === '.' ? slug : `${parentDir}/${slug}`;
+      const isAbsoluteSlug = rawSlug.startsWith('/');
+      const overriddenTail =
+        isAbsoluteSlug || parentDir === '.' ? slug : `${parentDir}/${slug}`;
       const match = findMatchingRoute(scopedRoutes, overriddenTail);
       if (match) return match;
     }

--- a/tests/test-frontmatter-slug-priority.js
+++ b/tests/test-frontmatter-slug-priority.js
@@ -169,7 +169,55 @@ async function testExplicitSlugWins() {
   }
 }
 
-// Test 3: documents without slug/id still resolve via the filename heuristic
+// Test 3: an absolute slug (leading "/") that flattens a page out of its folder
+// resolves to the flat route, not <parentDir>/<slug>.
+async function testAbsoluteSlugFlattening() {
+  const name = 'absolute slug flattening a nested page resolves to the flat route';
+  const { tmpDir, outDir } = makeSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'docs', 'section'), { recursive: true });
+    // Nested file, but its absolute slug lifts it to the site root (/flat-page).
+    fs.writeFileSync(
+      path.join(tmpDir, 'docs', 'section', 'nested-page.md'),
+      page('Flat Page', 'Body.', { slug: '/flat-page' })
+    );
+
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      generateLLMsFullTxt: false,
+      generateMarkdownFiles: true,
+      docsDir: [{ path: 'docs', routeBasePath: '/' }],
+    });
+    // Real Docusaurus route: the page is at "/flat-page", not
+    // "/section/nested-page".
+    await p.postBuild({ routesPaths: ['/flat-page'] });
+
+    const llms = fs.readFileSync(path.join(outDir, 'llms.txt'), 'utf8');
+    const files = walk(outDir).map(f => path.relative(outDir, f).split(path.sep).join('/'));
+
+    // The markdown lands at the flat route, and llms.txt links it there — no
+    // stray /section/ prefix and no raw docs/ fallback path.
+    assert.ok(
+      files.includes('flat-page.md'),
+      `page should produce flat-page.md at the root; got ${files.join(', ')}`
+    );
+    assert.ok(
+      llms.includes('https://example.com/flat-page.md'),
+      'page should be linked at its absolute slug /flat-page.md'
+    );
+    assert.ok(
+      !llms.includes('/section/'),
+      'link must not carry the source folder it was flattened out of'
+    );
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 4: documents without slug/id still resolve via the filename heuristic
 async function testNoOverrideUnaffected() {
   const name = 'documents without slug/id still resolve via filename heuristic';
   const { tmpDir, outDir } = makeSite();
@@ -204,6 +252,7 @@ async function testNoOverrideUnaffected() {
 async function main() {
   await testRootSlugWins();
   await testExplicitSlugWins();
+  await testAbsoluteSlugFlattening();
   await testNoOverrideUnaffected();
 
   console.log('\n' + '='.repeat(50));


### PR DESCRIPTION
## Summary

`resolveDocumentUrl()` mishandles **absolute** frontmatter slugs (a slug with a leading `/`). The frontmatter slug/id priority added in #59 always prefixes the slug with the file's parent directory before matching it against `routesPaths`. That is correct for a *relative* slug, but a Docusaurus slug beginning with `/` is **absolute** — resolved against the docs instance's `routeBasePath`, independent of where the file sits on disk. So prefixing the parent directory makes it unmatchable.

The effect: any page route deliberately flattened out of its folder never resolves to its real route. It falls through to the filename-tail heuristic and finally to the raw file-path fallback, so `llms.txt` links a path that isn't served and `generateMarkdownFiles` writes the page there, meaning "append `.md` to the page URL" 404s.

## Reproduction

```
docs/
  section/
    nested-page.md    # frontmatter: slug: /flat-page
```

Real Docusaurus route: `/flat-page`.

- **Before:** `llms.txt` links `…/docs/section/nested-page.md`, and the markdown is written at that path.
- **After:** `llms.txt` links `…/flat-page.md`, written at the flat route.

This affects any docs set that uses `slug` to lift nested pages to shorter URLs, common with `routeBasePath: '/'`, where it can hit a sizeable fraction of pages.

## Root cause

In `resolveDocumentUrl()` (`src/processor.ts`):

```ts
const slug = rawSlug.replace(/^\/+|\/+$/g, '');
if (!isNonEmptyString(slug)) continue;
const parentDir = path.dirname(tail);
const overriddenTail = parentDir === '.' ? slug : `${parentDir}/${slug}`; // ← always prefixes parentDir
const match = findMatchingRoute(scopedRoutes, overriddenTail);
```

For `section/nested-page.md` the tail is `section/nested-page`, so `overriddenTail` becomes `section/flat-page` — but the route is `/flat-page`, which never ends with that. It only happens to work when the file already lives at the docs root (`parentDir === '.'`), which is why top-level pages survive and nested flattened ones don't.

## The fix

Treat a leading-slash slug as absolute and match it directly; keep prefixing the parent directory only for relative slugs. `id` overrides never start with `/`, so their behaviour is unchanged.

```ts
const parentDir = path.dirname(tail);
const isAbsoluteSlug = rawSlug.startsWith('/');
const overriddenTail =
  isAbsoluteSlug || parentDir === '.' ? slug : `${parentDir}/${slug}`;
const match = findMatchingRoute(scopedRoutes, overriddenTail);
```

`findMatchingRoute`'s suffix matching already handles `routeBasePath` and version prefixes (an absolute slug `/foo` in a `/some-base` instance matches `/some-base/foo`), so no extra base handling is needed. When a doc declares `slug: /foo`, Docusaurus emits the route `/foo`, and `findMatchingRoute` prefers the shortest match, so it can't be stolen by a longer coincidental route.

## Testing

Adds a regression test to `tests/test-frontmatter-slug-priority.js` (`testAbsoluteSlugFlattening`): a nested `docs/section/nested-page.md` with `slug: /flat-page` must emit `flat-page.md` and link `/flat-page.md`, with no `/section/` prefix.

- Full `npm run test:unit` and `npm run test:integration` pass with no regressions.

## Scope / compatibility

- Behaviour changes only for absolute slugs on files not already at the docs root — precisely the broken case.
- Relative slugs, `id` overrides, `slug: "/"` root pages, and the filename heuristic are all unaffected.
- No API or option changes.

Relates to #59 (the frontmatter slug/id priority this builds on).