### PR TITLE
docs: suggest validating the deployed llms.txt in CI

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -77,6 +77,24 @@ clean file per language with `customLLMFiles`. Each entry needs a `filename`, an
 files](./content-generation.md) for the full field reference, including
 `ignorePatterns`, `orderPatterns`, and per-file `version`.
 
+## Validating the deployed output
+
+This plugin generates a correct `llms.txt` at build time, but serving-layer
+config can break it in production: host redirect rules, `trailingSlash`
+interactions, and docs restructures all bite after the build goes green.
+Docusaurus sites have shipped zero-byte llms.txt files and dead links this way.
+
+[llms-txt-check](https://github.com/portdeveloper/llms-txt-check) verifies the
+deployed file against what your site actually serves:
+
+```yaml
+- run: npx llms-txt-check https://your-docs-site.com
+```
+
+It exits nonzero when the file or any listed URL stops serving, so the deploy
+that breaks a route goes red. Run it as a final step in your deploy pipeline,
+after the site is live.
+
 ## Performance considerations
 
 Content cleaning is cheap. A few things worth knowing:


### PR DESCRIPTION
hey! i maintain docusaurus-plugin-copy-page-button so i spend a lot of time around docusaurus docs sites. i built a checker that validates deployed llms.txt files and ran it against a bunch of production sites this week: the failures i found were never the generator's fault, they were serving-layer breakage after the build (a Docusaurus site serving a zero-byte llms.txt via a trailingSlash interaction, another with stale routes after a restructure, e.g. BerriAI/litellm#36342). this PR adds a short README section pointing users at a CI check so your plugin's output stays healthy in production. happy to reword or trim to taste!