### PR TITLE
feat: fix wrong path prefixes when using multiple docsDirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ module.exports = {
 
 | Option                           | Type     | Default           | Description                                                   |
 |----------------------------------|----------|-------------------|---------------------------------------------------------------|
+| `blogDir`                        | string   | `'blog'`          | Filesystem path to the blog content directory, relative to the site root |
+| `blogRouteBasePath`              | string   | `'blog'`          | Docusaurus routeBasePath for the blog plugin — set this to match `presets.blog.routeBasePath` if you've customized it (e.g. `'news'`) |
 | `description`                    | string   | Site tagline      | Custom description to use in generated files                  |
 | `docsDir`                        | string \| object[] | `'docs'`          | Documentation source. A string base directory, or an array of section objects for multi-instance setups (see [Multiple documentation sections](#multiple-documentation-sections)) |
 | `excludeImports`                 | boolean  | `false`           | Remove import statements from generated content                |

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,7 +4,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { DocInfo, PluginContext, CustomLLMFile } from './types';
+import { DocInfo, DocsSection, PluginContext, CustomLLMFile } from './types';
 import {
   writeFile,
   readMarkdownFiles,
@@ -263,13 +263,25 @@ function buildFallbackPath(docPath: string, docsDir: string, preserveDirectorySt
 }
 
 /**
+ * Find the docsDir section that owns a doc by matching its filesystem path
+ * against each section's `path`.
+ */
+function findSectionForDoc(doc: DocInfo, docsSections?: DocsSection[]): DocsSection | undefined {
+  return docsSections?.find(s => {
+    const sectionPath = s.path.replace(/^\/+|\/+$/g, '');
+    return doc.path === sectionPath || doc.path.startsWith(`${sectionPath}/`);
+  });
+}
+
+/**
  * Generate individual markdown files for each document
  * @param docs - Processed document information
  * @param outputDir - Directory to write the markdown files
  * @param siteUrl - Base site URL
- * @param docsDir - The configured docs directory name (e.g., 'docs', 'documentation', etc.)
+ * @param docsDir - The configured docs directory name (e.g., 'docs', 'documentation', etc.); used as a fallback for docs that don't match any entry in `docsSections`
  * @param keepFrontMatter - Array of frontmatter keys to preserve in generated files
  * @param preserveDirectoryStructure - Whether to preserve the full directory structure (default: true)
+ * @param docsSections - Configured docsDir sections, used to resolve each doc's own filesystem path and routeBasePath
  * @returns Updated docs with new URLs pointing to generated markdown files
  */
 export async function generateIndividualMarkdownFiles(
@@ -278,7 +290,8 @@ export async function generateIndividualMarkdownFiles(
   siteUrl: string,
   docsDir: string = 'docs',
   keepFrontMatter: string[] = [],
-  preserveDirectoryStructure: boolean = true
+  preserveDirectoryStructure: boolean = true,
+  docsSections?: DocsSection[]
 ): Promise<DocInfo[]> {
   const updatedDocs: DocInfo[] = [];
   const usedPaths = new Set<string>();
@@ -298,6 +311,11 @@ export async function generateIndividualMarkdownFiles(
   }
 
   for (const doc of docs) {
+    // Resolve this doc's own section rather than just using the first section's docsDir.
+    const matchedSection = findSectionForDoc(doc, docsSections);
+    const sectionFsPath = matchedSection?.path ?? docsDir;
+    const sectionRouteBasePath = matchedSection?.routeBasePath ?? docsDir;
+
     // Derive output path from the resolved page URL (already stripped of numeric
     // prefixes like "01-" by Docusaurus). Fallback to doc.path when URL is
     // unavailable or malformed.
@@ -340,12 +358,12 @@ export async function generateIndividualMarkdownFiles(
             // ends in .md/.mdx (e.g. in tests or external usage).
             .replace(/\.mdx?$/i, '');
 
-          // When not preserving directory structure, drop the leading docsDir
+          // When not preserving directory structure, drop the leading route-base
           // segment so paths are flattened relative to the docs root — matching
           // buildFallbackPath and the pre-existing preserveDirectoryStructure
-          // contract (the URL pathname otherwise retains the "docs/" route base).
-          if (!preserveDirectoryStructure && isNonEmptyString(docsDir)) {
-            const prefix = `${docsDir.replace(/^\/+|\/+$/g, '')}/`;
+          // contract (the URL pathname otherwise retains the route base).
+          if (!preserveDirectoryStructure && isNonEmptyString(sectionRouteBasePath)) {
+            const prefix = `${sectionRouteBasePath.replace(/^\/+|\/+$/g, '')}/`;
             if (cleanPathname.startsWith(prefix)) {
               cleanPathname = cleanPathname.slice(prefix.length);
             }
@@ -355,11 +373,11 @@ export async function generateIndividualMarkdownFiles(
         }
       } catch {
         // Malformed URL — fall back to file path with prefix stripping
-        relativePath = buildFallbackPath(doc.path, docsDir, preserveDirectoryStructure);
+        relativePath = buildFallbackPath(doc.path, sectionFsPath, preserveDirectoryStructure);
       }
     } else {
       // No URL available — fall back to file path (legacy behaviour)
-      relativePath = buildFallbackPath(doc.path, docsDir, preserveDirectoryStructure);
+      relativePath = buildFallbackPath(doc.path, sectionFsPath, preserveDirectoryStructure);
     }
 
     // If frontmatter has slug, use that.
@@ -555,7 +573,8 @@ export async function generateStandardLLMFiles(
       siteUrl,
       context.docsDir,
       context.options.keepFrontMatter || [],
-      context.options.preserveDirectoryStructure !== false // Default to true
+      context.options.preserveDirectoryStructure !== false, // Default to true
+      context.docsSections
     );
   }
 
@@ -655,7 +674,8 @@ export async function generateCustomLLMFiles(
           siteUrl,
           context.docsDir,
           context.options.keepFrontMatter || [],
-          context.options.preserveDirectoryStructure !== false // Default to true
+          context.options.preserveDirectoryStructure !== false, // Default to true
+          context.docsSections
         );
       }
 
@@ -698,7 +718,7 @@ export async function generateCustomLLMFiles(
  */
 export async function collectDocFiles(context: PluginContext): Promise<string[]> {
   const { siteDir, options, docsSections } = context;
-  const { ignoreFiles = [], includeBlog = false, warnOnIgnoredFiles = false } = options;
+  const { ignoreFiles = [], includeBlog = false, blogDir: blogDirOption = 'blog', warnOnIgnoredFiles = false } = options;
 
   const allDocFiles: string[] = [];
 
@@ -720,13 +740,13 @@ export async function collectDocFiles(context: PluginContext): Promise<string[]>
 
   // Process blog if enabled
   if (includeBlog) {
-    const blogDir = path.join(siteDir, 'blog');
+    const blogDir = path.join(siteDir, blogDirOption);
 
     try {
       await fs.access(blogDir);
 
       // Collect all markdown files from blog directory
-      const blogFiles = await readMarkdownFiles(blogDir, siteDir, ignoreFiles, context.docsDir, warnOnIgnoredFiles);
+      const blogFiles = await readMarkdownFiles(blogDir, siteDir, ignoreFiles, blogDirOption, warnOnIgnoredFiles);
       allDocFiles.push(...blogFiles);
 
     } catch (err: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,9 @@ function validatePluginOptions(options: PluginOptions): void {
     'llmsFullTxtFilename',
     'version',
     'rootContent',
-    'fullRootContent'
+    'fullRootContent',
+    'blogDir',
+    'blogRouteBasePath'
   ] as const;
 
   for (const option of stringOptions) {
@@ -454,6 +456,8 @@ export default function docusaurusPluginLLMs(
     llmsTxtFilename = 'llms.txt',
     llmsFullTxtFilename = 'llms-full.txt',
     includeBlog = false,
+    blogDir = 'blog',
+    blogRouteBasePath = 'blog',
     pathTransformation,
     includeOrder = [],
     includeUnmatchedLast = true,
@@ -526,6 +530,8 @@ export default function docusaurusPluginLLMs(
       llmsTxtFilename,
       llmsFullTxtFilename,
       includeBlog,
+      blogDir,
+      blogRouteBasePath,
       pathTransformation,
       includeOrder,
       includeUnmatchedLast,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -5,7 +5,7 @@
 import * as path from 'path';
 import matter from 'gray-matter';
 import { minimatch } from 'minimatch';
-import { DocInfo, PluginContext } from './types';
+import { DocInfo, DocsSection, PluginContext } from './types';
 import {
   readFile,
   extractTitle,
@@ -45,7 +45,8 @@ export async function processMarkdownFile(
   resolvedUrl?: string,
   imageAssetMap?: Map<string, string[]>,
   outDir?: string,
-  siteDir?: string
+  siteDir?: string,
+  sectionPath?: string
 ): Promise<DocInfo | null> {
   const content = await readFile(filePath);
   const { data, content: markdownContent } = matter(content);
@@ -100,10 +101,21 @@ export async function processMarkdownFile(
     const linkPathBase = normalizedPath.replace(/\.mdx?$/, '');
     
     // Handle index files specially
-    let linkPath = linkPathBase.endsWith('index') 
-      ? linkPathBase.replace(/\/index$/, '') 
+    let linkPath = linkPathBase.endsWith('index')
+      ? linkPathBase.replace(/\/index$/, '')
       : linkPathBase;
-    
+
+    // linkPath is filesystem-relative while pathPrefix is a route, so strip
+    // the section's own filesystem path first when the two differ.
+    if (isNonEmptyString(sectionPath)) {
+      const cleanSectionPath = sectionPath.replace(/^\/+|\/+$/g, '');
+      if (cleanSectionPath && linkPath.startsWith(`${cleanSectionPath}/`)) {
+        linkPath = linkPath.substring(`${cleanSectionPath}/`.length);
+      } else if (cleanSectionPath && linkPath === cleanSectionPath) {
+        linkPath = '';
+      }
+    }
+
     // pathPrefix may carry a trailing slash (e.g. docsDir: 'foo/'); normalize it
     // so prefix matching and URL assembly never produce a doubled slash (#43).
     const cleanPrefix = pathPrefix ? pathPrefix.replace(/\/+$/, '') : pathPrefix;
@@ -336,27 +348,54 @@ async function resolveDocumentUrl(
 ): Promise<string | undefined> {
   if (!context.routesPaths?.length) return undefined;
 
-  const { docsDir } = context;
+  // context.docsDir is only ever the first section's path, so find the
+  // section that actually owns this file instead.
+  const matchedSection = context.docsSections?.find(s => {
+    const abs = path.resolve(baseDir, s.path);
+    return filePath.startsWith(abs + path.sep) || filePath.startsWith(abs + '/');
+  });
+  const { blogDir = 'blog', blogRouteBasePath = 'blog' } = context.options;
+  const isBlogFile = !matchedSection && filePath.includes(path.join(baseDir, blogDir));
+  const sectionFsPath = matchedSection?.path ?? (isBlogFile ? blogDir : context.docsDir);
 
   // In multi-version mode, restrict matching to routes owned by this version so
   // links resolve within the correct subtree (e.g. a 'stable' doc links to
   // /stable/... and the root version's links avoid versioned subtrees).
-  const scopedRoutes = scopeRoutesToVersion(
+  let scopedRoutes = scopeRoutesToVersion(
     context.routesPaths,
     context.routePrefix,
     context.siblingPrefixes
   );
+
+  // Also restrict to this file's own section (or the blog), so a same-named
+  // file elsewhere (e.g. two docsDir entries each with a faq.md) can't
+  // suffix-match this file's tail and steal its route. Skipped for a single
+  // implicit docs section (e.g. a plain string docsDir), whose routeBasePath
+  // is defaulted to its filesystem path and doesn't necessarily reflect the
+  // real route.
+  const routeBase = isBlogFile
+    ? blogRouteBasePath
+    : matchedSection && (context.docsSections?.length ?? 0) > 1
+      ? matchedSection.routeBasePath
+      : undefined;
+  if (routeBase && routeBase !== '/') {
+    const versionPrefix = context.routePrefix ? context.routePrefix.replace(/\/+$/, '') : '';
+    const scopedRouteBase = `${versionPrefix}/${routeBase}`.replace(/\/+$/, '');
+    scopedRoutes = scopedRoutes.filter(
+      r => r === scopedRouteBase || r.startsWith(`${scopedRouteBase}/`)
+    );
+  }
   if (!scopedRoutes.length) return undefined;
 
   const relative = normalizePath(path.relative(baseDir, filePath))
     .replace(/\.mdx?$/, '')
     .replace(/\/index$/, '');
 
-  // Strip the docsDir prefix — docsDir is the filesystem root for the docs
-  // plugin, which Docusaurus removes when computing routes
+  // Strip the matched section's filesystem path — this is the filesystem root
+  // Docusaurus removes when computing routes for files under this section.
   let tail = relative;
-  if (docsDir && tail.startsWith(`${docsDir}/`)) {
-    tail = tail.substring(`${docsDir}/`.length);
+  if (sectionFsPath && tail.startsWith(`${sectionFsPath}/`)) {
+    tail = tail.substring(`${sectionFsPath}/`.length);
   }
 
   // An explicit `slug`/`id` in frontmatter unambiguously declares the document's
@@ -377,16 +416,10 @@ async function resolveDocumentUrl(
       // A plain slug strip would produce "" and skip; instead find the section this
       // file belongs to and use its routeBasePath to locate the correct route.
       if (/^\/+$/.test(rawSlug)) {
-        // Determine which section owns this file to get the correct base route.
+        // Use the section already matched above to get the correct base route.
         let sectionBase = '/';
-        if (context.docsSections?.length > 0) {
-          const matched = context.docsSections.find(s => {
-            const abs = path.resolve(baseDir, s.path);
-            return filePath.startsWith(abs + path.sep) || filePath.startsWith(abs + '/');
-          });
-          if (matched && matched.routeBasePath !== '/') {
-            sectionBase = `/${matched.routeBasePath}`;
-          }
+        if (matchedSection && matchedSection.routeBasePath !== '/') {
+          sectionBase = `/${matchedSection.routeBasePath}`;
         }
         // Look for an exact or trailing-slash-equivalent route in routesPaths.
         const rootMatch = context.routesPaths.find(r => {
@@ -439,31 +472,28 @@ async function resolveDocumentUrl(
  * Helper function to check if a file matches a pattern
  * Tries matching against multiple path variants for better usability
  */
-function matchesPattern(file: string, pattern: string, siteDir: string, docsDir: string): boolean {
+function matchesPattern(file: string, pattern: string, siteDir: string, docsDir: string, docsSections?: DocsSection[]): boolean {
   const minimatchOptions = { matchBase: true };
 
   // Get site-relative path (e.g., "docs/quickstart/file.md")
   const siteRelativePath = normalizePath(path.relative(siteDir, file));
-
-  // Get docs-relative path (e.g., "quickstart/file.md")
-  // Normalize both paths to handle different path separators and resolve any .. or .
-  const docsBaseDir = path.resolve(path.join(siteDir, docsDir));
-  const resolvedFile = path.resolve(file);
-  const docsRelativePath = resolvedFile.startsWith(docsBaseDir)
-    ? normalizePath(path.relative(docsBaseDir, resolvedFile))
-    : null;
 
   // Try matching against site-relative path
   if (minimatch(siteRelativePath, pattern, minimatchOptions)) {
     return true;
   }
 
-  // Try matching against docs-relative path if available
-  if (docsRelativePath && minimatch(docsRelativePath, pattern, minimatchOptions)) {
-    return true;
-  }
+  // Get docs-relative path (e.g., "quickstart/file.md") against every
+  // configured section, not just the first.
+  const resolvedFile = path.resolve(file);
+  const sectionPaths = docsSections?.length ? docsSections.map(s => s.path) : [docsDir];
 
-  return false;
+  return sectionPaths.some(sectionPath => {
+    const docsBaseDir = path.resolve(path.join(siteDir, sectionPath));
+    if (!resolvedFile.startsWith(docsBaseDir)) return false;
+    const docsRelativePath = normalizePath(path.relative(docsBaseDir, resolvedFile));
+    return minimatch(docsRelativePath, pattern, minimatchOptions);
+  });
 }
 
 export async function processFilesWithPatterns(
@@ -474,38 +504,39 @@ export async function processFilesWithPatterns(
   orderPatterns: string[] = [],
   includeUnmatched: boolean = false
 ): Promise<DocInfo[]> {
-  const { siteDir, siteUrl, docsDir } = context;
-  
+  const { siteDir, siteUrl, docsDir, docsSections } = context;
+  const { blogDir = 'blog', blogRouteBasePath = 'blog' } = context.options;
+
   // Filter files based on include patterns
   let filteredFiles = allFiles;
-  
+
   if (includePatterns.length > 0) {
     filteredFiles = allFiles.filter(file => {
       return includePatterns.some(pattern =>
-        matchesPattern(file, pattern, siteDir, docsDir)
+        matchesPattern(file, pattern, siteDir, docsDir, docsSections)
       );
     });
   }
-  
+
   // Apply ignore patterns
   if (ignorePatterns.length > 0) {
     filteredFiles = filteredFiles.filter(file => {
       return !ignorePatterns.some(pattern =>
-        matchesPattern(file, pattern, siteDir, docsDir)
+        matchesPattern(file, pattern, siteDir, docsDir, docsSections)
       );
     });
   }
-  
+
   // Order files according to orderPatterns
   let filesToProcess: string[] = [];
-  
+
   if (orderPatterns.length > 0) {
     const matchedFiles = new Set<string>();
-    
+
     // Process files according to orderPatterns
     for (const pattern of orderPatterns) {
       const matchingFiles = filteredFiles.filter(file => {
-        return matchesPattern(file, pattern, siteDir, docsDir) && !matchedFiles.has(file);
+        return matchesPattern(file, pattern, siteDir, docsDir, docsSections) && !matchedFiles.has(file);
       });
       
       for (const file of matchingFiles) {
@@ -528,14 +559,17 @@ export async function processFilesWithPatterns(
     filesToProcess.map(async (filePath) => {
       try {
         const baseDir = siteDir;
-        const isBlogFile = filePath.includes(path.join(siteDir, 'blog'));
+        const isBlogFile = filePath.includes(path.join(siteDir, blogDir));
 
         // Determine which section this file belongs to
         let pathPrefix: string;
         let sectionLabel: string | undefined;
+        // The section's filesystem path, as opposed to pathPrefix (its route).
+        let sectionFsPath: string | undefined;
 
         if (isBlogFile) {
-          pathPrefix = 'blog';
+          pathPrefix = blogRouteBasePath;
+          sectionFsPath = blogDir;
         } else if (context.docsSections && context.docsSections.length > 0) {
           const matchedSection = context.docsSections.find(s => {
             const sectionDir = path.join(siteDir, s.path);
@@ -544,6 +578,7 @@ export async function processFilesWithPatterns(
 
           if (matchedSection) {
             pathPrefix = matchedSection.routeBasePath;
+            sectionFsPath = matchedSection.path;
             if (context.docsSections.length > 1) {
               sectionLabel = matchedSection.label || matchedSection.path;
             }
@@ -571,7 +606,8 @@ export async function processFilesWithPatterns(
           resolvedUrl,
           context.imageAssetMap,
           context.options.rewriteImageUrls ? context.outDir : undefined,
-          siteDir
+          siteDir,
+          sectionFsPath
         );
 
         if (docInfo && sectionLabel) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,13 @@ export interface PluginOptions {
   
   /** Whether to include blog content (default: false) */
   includeBlog?: boolean;
-  
+
+  /** Filesystem path to the blog content directory, relative to siteDir (default: 'blog') */
+  blogDir?: string;
+
+  /** Docusaurus routeBasePath for the blog plugin (default: 'blog'). Set this to match `presets.blog.routeBasePath` if you've customized it (e.g. 'news'). */
+  blogRouteBasePath?: string;
+
   /** Path transformation options for URL construction */
   pathTransformation?: {
     /** Path segments to ignore when constructing URLs (will be removed if found) */

--- a/tests/test-multi-doc.js
+++ b/tests/test-multi-doc.js
@@ -55,6 +55,31 @@ function cleanup(tmpDir) {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }
 
+/**
+ * Create a temp site with two sections whose filesystem `path` differs from
+ * their `routeBasePath` (e.g. { path: 'team-a/docs', routeBasePath: 'docs/team-a' }).
+ */
+function createMismatchedPathSite() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plugin-llms-test-'));
+  const outDir = path.join(tmpDir, 'out');
+
+  fs.mkdirSync(path.join(tmpDir, 'team-a', 'docs'), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, 'team-b', 'docs'), { recursive: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tmpDir, 'team-a', 'docs', 'getting-started.md'),
+    '---\ntitle: Getting Started\ndescription: Start here.\n---\n\n# Getting Started\n\nStart here.'
+  );
+
+  fs.writeFileSync(
+    path.join(tmpDir, 'team-b', 'docs', 'faq.md'),
+    '---\ntitle: FAQ\ndescription: Team B FAQ.\n---\n\n# FAQ\n\nTeam B FAQ.'
+  );
+
+  return { tmpDir, outDir };
+}
+
 function makeMockContext(tmpDir, outDir) {
   return {
     siteDir: tmpDir,
@@ -255,6 +280,150 @@ async function testFullTxtContainsBothSections() {
   }
 }
 
+// Test 7: Every section's own filesystem path is stripped, not just the first
+async function testAllSectionsWithMismatchedPaths() {
+  const name = 'All sections with diverging path/routeBasePath get correct URLs';
+  const { tmpDir, outDir } = createMismatchedPathSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'team-a/docs', routeBasePath: 'docs/team-a' },
+        { path: 'team-b/docs', routeBasePath: 'docs/team-b' },
+      ],
+      llmsTxtFilename: 'llms-test7.txt',
+      llmsFullTxtFilename: 'llms-full-test7.txt',
+    });
+    await p.postBuild({ routesPaths: ['/docs/team-a/getting-started', '/docs/team-b/faq'] });
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test7.txt'), 'utf8');
+
+    assert.ok(
+      content.includes('(https://example.com/docs/team-a/getting-started)'),
+      `Expected clean URL for first section, got:\n${content}`
+    );
+    assert.ok(
+      content.includes('(https://example.com/docs/team-b/faq)'),
+      `Expected clean URL for second section, got:\n${content}`
+    );
+    // The heading legitimately falls back to the raw path as a label — only
+    // the URL itself must never contain it.
+    assert.ok(
+      !content.includes('docs/team-b/team-b'),
+      `URL must not leak the second section's filesystem path, got:\n${content}`
+    );
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 8: generateMarkdownFiles flattens every section, not just the first
+async function testFlattenedMarkdownFilesForAllSections() {
+  const name = 'generateMarkdownFiles flattens every section, not just the first';
+  const { tmpDir, outDir } = createMismatchedPathSite();
+  try {
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'team-a/docs', routeBasePath: 'docs/team-a' },
+        { path: 'team-b/docs', routeBasePath: 'docs/team-b' },
+      ],
+      generateMarkdownFiles: true,
+      preserveDirectoryStructure: false,
+      llmsTxtFilename: 'llms-test8.txt',
+      llmsFullTxtFilename: 'llms-full-test8.txt',
+    });
+    await p.postBuild({ routesPaths: ['/docs/team-a/getting-started', '/docs/team-b/faq'] });
+
+    assert.ok(fs.existsSync(path.join(outDir, 'getting-started.md')), 'Expected first section file flattened to getting-started.md');
+    assert.ok(fs.existsSync(path.join(outDir, 'faq.md')), 'Expected second section file flattened to faq.md');
+    assert.ok(!fs.existsSync(path.join(outDir, 'team-b')), 'Second section filesystem directory must not leak into the flattened output');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 9: docs-relative include patterns match files in every section, not just the first
+async function testDocsRelativePatternMatchesAllSections() {
+  const name = 'docs-relative include patterns match files in every section';
+  const { tmpDir, outDir } = createMismatchedPathSite();
+  try {
+    fs.mkdirSync(path.join(tmpDir, 'team-b', 'docs', 'guides'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'team-b', 'docs', 'guides', 'setup.md'),
+      '---\ntitle: Setup Guide\ndescription: Team B setup guide.\n---\n\n# Setup Guide\n\nTeam B setup guide.'
+    );
+
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'team-a/docs', routeBasePath: 'docs/team-a' },
+        { path: 'team-b/docs', routeBasePath: 'docs/team-b' },
+      ],
+      customLLMFiles: [
+        {
+          filename: 'llms-guides-test9.txt',
+          includePatterns: ['guides/*.md'],
+          fullContent: false,
+        },
+      ],
+    });
+    await p.postBuild({ routesPaths: ['/docs/team-a/getting-started', '/docs/team-b/faq', '/docs/team-b/guides/setup'] });
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-guides-test9.txt'), 'utf8');
+    assert.ok(content.includes('Setup Guide'), `Expected team-b's guides/setup.md to match "guides/*.md", got:\n${content}`);
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+// Test 10: A file with the same relative path in two sections (e.g. faq.md in
+// both) must not resolve to the same route — each keeps its own section's URL.
+async function testSameBasenameAcrossSectionsDoesNotCollide() {
+  const name = 'Same-named files in different sections resolve to distinct URLs';
+  const { tmpDir, outDir } = createMismatchedPathSite();
+  try {
+    fs.writeFileSync(
+      path.join(tmpDir, 'team-a', 'docs', 'faq.md'),
+      '---\ntitle: FAQ\ndescription: Team A FAQ.\n---\n\n# FAQ\n\nTeam A FAQ.'
+    );
+
+    const p = plugin(makeMockContext(tmpDir, outDir), {
+      docsDir: [
+        { path: 'team-a/docs', routeBasePath: 'docs/team-a' },
+        { path: 'team-b/docs', routeBasePath: 'docs/team-b' },
+      ],
+      generateMarkdownFiles: true,
+      llmsTxtFilename: 'llms-test10.txt',
+      llmsFullTxtFilename: 'llms-full-test10.txt',
+    });
+    await p.postBuild({ routesPaths: ['/docs/team-a/getting-started', '/docs/team-a/faq', '/docs/team-b/faq'] });
+
+    const content = fs.readFileSync(path.join(outDir, 'llms-test10.txt'), 'utf8');
+
+    assert.ok(content.includes('(https://example.com/docs/team-a/faq.md)'), `Expected team-a's faq at its own URL, got:\n${content}`);
+    assert.ok(content.includes('(https://example.com/docs/team-b/faq.md)'), `Expected team-b's faq at its own URL, got:\n${content}`);
+    assert.ok(!content.includes('faq-2'), `No file should need a "-2" suffix to disambiguate, got:\n${content}`);
+    assert.ok(fs.existsSync(path.join(outDir, 'docs', 'team-a', 'faq.md')), 'Expected team-a/faq.md written to its own section directory');
+    assert.ok(fs.existsSync(path.join(outDir, 'docs', 'team-b', 'faq.md')), 'Expected team-b/faq.md written to its own section directory');
+
+    pass(name);
+  } catch (err) {
+    fail(name, err.message);
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
 async function main() {
   await testTwoLabeledSections();
   await testLabelFallbackToPath();
@@ -262,6 +431,10 @@ async function main() {
   await testSingleArrayEntry();
   await testValidationRejectsInvalidArray();
   await testFullTxtContainsBothSections();
+  await testAllSectionsWithMismatchedPaths();
+  await testFlattenedMarkdownFilesForAllSections();
+  await testDocsRelativePatternMatchesAllSections();
+  await testSameBasenameAcrossSectionsDoesNotCollide();
 
   console.log('\n' + '='.repeat(50));
   console.log(`Test Results: ${passedTests}/${passedTests + failedTests} passed, ${failedTests} failed`);


### PR DESCRIPTION
## Summary

Fixes multiple bugs where `docsDir` configured as an array of sections only worked correctly for the *first* section. Root cause: the plugin collapsed multi-section config down to a single `docsDir` string internally and reused it everywhere instead of resolving each file's own section.

- **Wrong URLs for non-first sections** - when a section's filesystem path differs from its `routeBasePath`, only the first section had its path correctly stripped from generated URLs; every other section leaked its raw directory into the output.
- **Same-named files across sections collided** - a file with the same name in two sections could resolve to the same route, silently dropping one file's link/output in favor of a `-2` suffixed duplicate in the wrong section.
- **Blog `routeBasePath` was hardcoded** - the plugin assumed the blog always lives at `blog`, breaking output when `presets.blog.routeBasePath` is customized. Added `blogDir`/`blogRouteBasePath` options (defaulting to the previous behavior) to make this configurable.

## Testing

Added regression tests covering all three scenarios; verified they fail on the pre-fix code and pass after. Existing test suites still pass - no behavior change for single-section (string `docsDir`) configs.
